### PR TITLE
fix: remove @dataclass_transform from AppContainerMeta

### DIFF
--- a/src/redsun/containers/container.py
+++ b/src/redsun/containers/container.py
@@ -28,7 +28,6 @@ from typing import (
 import yaml
 from dependency_injector import containers, providers
 from sunflare.virtual import HasShutdown, IsInjectable, IsProvider, VirtualBus
-from typing_extensions import dataclass_transform
 
 from .components import (
     RedSunConfig,
@@ -203,7 +202,6 @@ def _resolve_frontend_container(frontend: str) -> type[AppContainer]:
     return ret_cls
 
 
-@dataclass_transform(field_specifiers=(component,))
 class AppContainerMeta(type):
     """Metaclass that auto-collects component wrappers from class attributes.
 


### PR DESCRIPTION
## Summary

Removes the `@dataclass_transform(field_specifiers=(component,))` decorator from `AppContainerMeta` and the now-unused `from typing_extensions import dataclass_transform` import.

## Why

`@dataclass_transform` is intended for frameworks that **generate `__init__`** from annotated class fields (attrs, pydantic, SQLModel, etc.). `AppContainerMeta` does not do this — it collects `_ComponentField` sentinels into internal registries at class-definition time. `AppContainer.__init__` only accepts `session` and `frontend`; it never receives the component fields as positional arguments.

The consequence is that any downstream package using the idiomatic annotation pattern gets a spurious mypy `call-arg` error on instantiation because mypy incorrectly infers `__init__` parameters from the annotated fields.

Redsun's own tests didn't surface this because they use the lower-level `_DeviceComponent(...)` wrappers without type annotations — the synthesised `__init__` is only triggered on annotated fields.

## Impact

- **Runtime**: none — the decorator only affects static type checkers.
- **Tests**: 31/31 pass unchanged.
- **Mypy**: 0 errors.
- **Downstream**: packages that added `disable_error_code = ["call-arg"]` as a workaround can remove that override once they pick up this release.