### PR TITLE
refactor: component() accepts class as first positional argument

### DIFF
--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -39,18 +39,18 @@ This separation ensures that hardware drivers, UI components, and business logic
 
 ## Declarative component registration
 
-Components are declared as annotated class attributes using the [`component()`][redsun.containers.components.component] field specifier:
+Components are declared as class attributes using the [`component()`][redsun.containers.components.component] field specifier, passing the component class as the first argument:
 
 ```python
 from redsun.containers import AppContainer, component
 
 class MyApp(AppContainer):
-    motor: MyMotor = component(layer="device", axis=["X", "Y"])
-    ctrl: MyController = component(layer="presenter", gain=1.0)
-    ui: MyView = component(layer="view")
+    motor = component(MyMotor, layer="device", axis=["X", "Y"])
+    ctrl = component(MyController, layer="presenter", gain=1.0)
+    ui = component(MyView, layer="view")
 ```
 
-The [`AppContainerMeta`][redsun.containers.container.AppContainerMeta] metaclass collects these declarations at class creation time, resolving type annotations to concrete component classes. This declarative approach allows the container to:
+The [`AppContainerMeta`][redsun.containers.container.AppContainerMeta] metaclass collects these declarations at class creation time. Because the class is passed directly to `component()`, no annotation inspection is needed. This declarative approach allows the container to:
 
 - validate component types at class creation time;
 - inherit and override components from base classes;
@@ -64,7 +64,7 @@ Components can pull their keyword arguments from a YAML configuration file:
 from redsun.containers import AppContainer, component
 
 class MyApp(AppContainer, config="app_config.yaml"):
-    motor: MyMotor = component(layer="device", from_config="motor")
+    motor = component(MyMotor, layer="device", from_config="motor")
 ```
 
 The configuration file provides base keyword arguments that can be overridden by inline values in the [`component()`][redsun.containers.components.component] call. This allows the same application class to be reused across different setups by swapping configuration files.

--- a/docs/explanation/plugin-system.md
+++ b/docs/explanation/plugin-system.md
@@ -97,7 +97,7 @@ The plugin system is used when building from configuration files via
 [`AppContainer.from_config()`][redsun.containers.container.AppContainer.from_config].
 When using the declarative class-based approach (defining a container subclass with
 [`component()`][redsun.containers.components.component] fields), component classes are
-specified directly through type annotations and do not go through plugin discovery.
+passed directly as the first argument to `component()` and do not go through plugin discovery.
 
 Both approaches produce the same result: an
 [`AppContainer`][redsun.containers.container.AppContainer] with registered device,

--- a/src/redsun/__init__.py
+++ b/src/redsun/__init__.py
@@ -1,6 +1,10 @@
 from importlib.metadata import PackageNotFoundError, version
 
+from redsun.containers import AppContainer, component
+
 try:
     __version__ = version("redsun")
 except PackageNotFoundError:
     __version__ = "unknown"
+
+__all__ = ["AppContainer", "component", "__version__"]

--- a/src/redsun/containers/__init__.py
+++ b/src/redsun/containers/__init__.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .components import RedSunConfig, component
+from .components import component
 from .container import AppContainer
 
-__all__ = ["AppContainer", "RedSunConfig", "component"]
+__all__ = ["AppContainer", "component"]


### PR DESCRIPTION
## Summary

Removes the type-hint resolution machinery from `AppContainerMeta.__new__` and instead requires the component class to be passed directly as the first argument to `component()`.

### API change

```python
# Before
class MyApp(AppContainer):
    motor: MyMotor = component(layer="device", axis=["X"])
    ctrl: MyController = component(layer="presenter")

# After
class MyApp(AppContainer):
    motor = component(MyMotor, layer="device", axis=["X"])
    ctrl = component(MyController, layer="presenter")
```

### Motivation

The old approach relied on `get_type_hints()` at class creation time to resolve the annotation into a concrete class. This had two problems:

1. It caused **all** `AppContainer` subclasses to be processed eagerly at import time (since the metaclass runs at class definition), even when only one configuration was needed.
2. It required a `sys._getframe(1)` fallback for classes defined inside functions, which is fragile.

Passing the class explicitly eliminates both: no annotation scanning, no frame inspection.

### Changes

- `_ComponentField` gains a `cls` slot
- `component()` takes `cls` as first positional argument; overloads updated
- `AppContainerMeta.__new__` drops the `get_type_hints` / `sys._getframe` block entirely
- `sys` and `get_type_hints` removed from `container.py` imports
- Tests updated to new call style; mixed-style test preserved using direct `_PresenterComponent` wrapper
- Docs updated
