### PR TITLE
fix: relax component() overloads to accept any type for all layers

### DIFF
--- a/src/redsun/containers/components.py
+++ b/src/redsun/containers/components.py
@@ -64,7 +64,7 @@ class _ComponentField:
 
 @overload
 def component(
-    cls: type[Device],
+    cls: type,
     *,
     layer: Literal["device"],
     alias: str | None = ...,
@@ -73,7 +73,7 @@ def component(
 ) -> Any: ...
 @overload
 def component(
-    cls: type[Presenter],
+    cls: type,
     *,
     layer: Literal["presenter"],
     alias: None = ...,
@@ -82,7 +82,7 @@ def component(
 ) -> Any: ...
 @overload
 def component(
-    cls: type[View],
+    cls: type,
     *,
     layer: Literal["view"],
     alias: None = ...,
@@ -107,8 +107,11 @@ def component(
     Parameters
     ----------
     cls : type
-        The component class to instantiate. Must be a `Device`,
-        `Presenter`, or `View` subclass matching the given ``layer``.
+        The component class to instantiate. For ``layer="device"`` this
+        must be a `Device` subclass. For ``layer="presenter"`` and
+        ``layer="view"`` any class with the appropriate constructor
+        signature is accepted, including protocol-based implementations
+        that do not inherit from `Presenter` or `View` directly.
     layer : "device" | "presenter" | "view"
         The layer this component belongs to.
     alias : str | None


### PR DESCRIPTION
## Problem

The overloads introduced in #13 used , ,  to constrain . This caused mypy errors in redsun-mimir for classes that are built from protocol mixins rather than inheriting these base classes directly (e.g. ,  which compose / rather than extending ).

The root cause is that , , and  are themselves  classes in sunflare, and mypy does not reliably match  against  in overload resolution.

## Fix

Relax all three overloads to plain . The  literal string still discriminates the overloads so callers get a clear error if they pass an invalid layer value; runtime validation of the class is unaffected.
