### PR TITLE
Remove unused container parameter from _PresenterComponent.build()

### DIFF
--- a/src/redsun/containers/components.py
+++ b/src/redsun/containers/components.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Generic, TypeVar
+from typing import Any, Generic, TypeVar
 
 from sunflare.device import Device
 from sunflare.presenter import Presenter
 from sunflare.view import View
-
-if TYPE_CHECKING:
-    from sunflare.virtual import VirtualContainer
-
 
 T = TypeVar("T")
 
@@ -192,9 +188,7 @@ class _DeviceComponent(_ComponentBase[Device]):
 class _PresenterComponent(_ComponentBase[Presenter]):
     """Presenter component wrapper."""
 
-    def build(
-        self, devices: dict[str, Device], container: VirtualContainer
-    ) -> Presenter:
+    def build(self, devices: dict[str, Device]) -> Presenter:
         """Build the presenter instance."""
         self._instance = self.cls(self.name, devices, **self.kwargs)
         return self.instance

--- a/src/redsun/containers/container.py
+++ b/src/redsun/containers/container.py
@@ -426,9 +426,7 @@ class AppContainer(metaclass=AppContainerMeta):
         # build presenters and optionally register their providers
         for comp_name, presenter_component in self._presenter_components.items():
             try:
-                presenter = presenter_component.build(
-                    built_devices, self._virtual_container
-                )
+                presenter = presenter_component.build(built_devices)
                 if isinstance(presenter, IsProvider):
                     presenter.register_providers(self._virtual_container)
             except Exception as e:

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -50,14 +50,12 @@ class TestComponentWrappers:
 
     def test_presenter_component_build(self) -> None:
         from mock_pkg.controller import MockController
-        from sunflare.virtual import VirtualContainer
 
         comp = _PresenterComponent(
             MockController, "ctrl",
             string="s", integer=1, floating=0.0, boolean=False,
         )
-        container = VirtualContainer()
-        presenter = comp.build({}, container)
+        presenter = comp.build({})
         assert presenter is comp.instance
         assert "built" in repr(comp)
 


### PR DESCRIPTION
The `VirtualContainer` argument was accepted by `_PresenterComponent.build()` but never used — the `IsProvider.register_providers()` call happens in the `AppContainer` build loop after construction, not inside the wrapper. Removing it cleans up the signature and eliminates a leftover from the old `VirtualBus` approach.