### PR TITLE
Replace plugin manifest indirection with direct class path loading

### DIFF
--- a/tests/configs/broken_factory_controller.yaml
+++ b/tests/configs/broken_factory_controller.yaml
@@ -3,8 +3,7 @@ frontend: pyqt
 session: broken-factory-session
 presenters:
   MockController:
-    plugin_name: mock-pkg
-    plugin_id: broken_controller
+    class: mock_pkg.controller:BrokenController
     string: "I am a mock controller"
     floating: 0.0
     integer: 43

--- a/tests/configs/broken_factory_model.yaml
+++ b/tests/configs/broken_factory_model.yaml
@@ -3,5 +3,4 @@ frontend: pyqt
 session: broken-factory-session
 devices:
   iSCAT channel:
-    plugin_name: mock-pkg
-    plugin_id: broken_init_model
+    class: mock_pkg.device:BrokenDevice

--- a/tests/configs/broken_model_config.yaml
+++ b/tests/configs/broken_model_config.yaml
@@ -3,15 +3,13 @@ frontend: pyqt
 session: broken-model-session
 devices:
   iSCAT channel:
-    plugin_name: mock-pkg
-    plugin_id: my_broken_model
+    class: mock_pkg.device:BrokenDevice
   TIRF channel:
-    plugin_name: mock-pkg
-    plugin_id: my_detector
-    sensor_shape: 
+    class: mock_pkg.device:MockDetector
+    sensor_shape:
       - 2400
       - 2048
-    pixel_size: 
+    pixel_size:
       - 17.5
       - 17.5
       - 17.5

--- a/tests/configs/hidden_model_config.yaml
+++ b/tests/configs/hidden_model_config.yaml
@@ -3,5 +3,4 @@ frontend: pyqt
 session: hidden-device-session
 devices:
   iSCAT channel:
-    plugin_name: mock-pkg
-    plugin_id: my_hidden_model
+    class: mock_pkg.device.hidden:HiddenModel

--- a/tests/configs/mock_controller_config.yaml
+++ b/tests/configs/mock_controller_config.yaml
@@ -3,8 +3,7 @@ frontend: pyqt
 session: mock-session
 presenters:
   MockController:
-    plugin_name: mock-pkg
-    plugin_id: my_controller
+    class: mock_pkg.controller:MockController
     string: "I am a mock controller"
     floating: 0.0
     integer: 43

--- a/tests/configs/mock_detector_config.yaml
+++ b/tests/configs/mock_detector_config.yaml
@@ -3,8 +3,7 @@ frontend: pyqt
 session: mock-session
 devices:
   iSCAT channel:
-    plugin_name: mock-pkg
-    plugin_id: my_detector
+    class: mock_pkg.device:MockDetector
     sensor_shape:
       - 1280
       - 864
@@ -18,12 +17,11 @@ devices:
     floating: 3.14
     string: "Hello, World!"
   TIRF channel:
-    plugin_name: mock-pkg
-    plugin_id: my_detector
-    sensor_shape: 
+    class: mock_pkg.device:MockDetector
+    sensor_shape:
       - 2400
       - 2048
-    pixel_size: 
+    pixel_size:
       - 17.5
       - 17.5
       - 17.5

--- a/tests/configs/mock_full_config.yaml
+++ b/tests/configs/mock_full_config.yaml
@@ -3,8 +3,7 @@ frontend: pyqt
 session: mock-session
 devices:
   Single axis motor:
-    plugin_name: mock-pkg
-    plugin_id: my_motor
+    class: mock_pkg.device:MyMotor
     axis: ["X"]
     step_size:
       X: 0.1
@@ -14,13 +13,11 @@ devices:
     string: "Hello, World!"
 presenters:
   MockController:
-    plugin_name: mock-pkg
-    plugin_id: my_controller
+    class: mock_pkg.controller:MockController
     string: "I am a mock controller"
     floating: 0.0
     integer: 43
     boolean: false
 views:
   MockView:
-    plugin_name: mock-pkg
-    plugin_id: mock_view
+    class: mock_pkg.view:MockQtView

--- a/tests/configs/mock_motor_config.yaml
+++ b/tests/configs/mock_motor_config.yaml
@@ -3,20 +3,18 @@ frontend: pyqt
 session: mock-session
 devices:
   Single axis motor:
-    plugin_name: mock-pkg
-    plugin_id: my_motor
+    class: mock_pkg.device:MyMotor
     axis: ["X"]
-    step_size: 
+    step_size:
       X: 0.1
     egu: mm
     integer: 42
     floating: 3.14
     string: "Hello, World!"
   Double axis motor:
-    plugin_name: mock-pkg
-    plugin_id: my_other_motor
+    class: mock_pkg.device:NonDerivedMotor
     axis: ["X", "Y"]
-    step_size: 
+    step_size:
       X: 0.1
       Y: 0.2
     egu: mm

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,70 +1,17 @@
 from __future__ import annotations
 
-import contextlib
 import sys
 from pathlib import Path
-from typing import Any, Generator
-from unittest import mock
 
 import pytest
-from importlib.metadata import EntryPoint
 
 # Add the test directory to sys.path so mock_pkg is importable
 _tests_dir = str(Path(__file__).parent)
 if _tests_dir not in sys.path:
     sys.path.insert(0, _tests_dir)
 
-_MOCK_PKG_DIR = Path(__file__).parent / "mock_pkg"
-
 
 @pytest.fixture
 def config_path() -> Path:
     """Return the path to test configuration files."""
     return Path(__file__).parent / "configs"
-
-
-def _make_mock_entry_point() -> mock.Mock:
-    """Create a mock entry point for the mock-pkg plugin."""
-    ep = mock.Mock(spec=EntryPoint)
-    ep.name = "mock-pkg"
-    ep.value = "redsun.yaml"
-    ep.group = "redsun.plugins"
-    return ep
-
-
-@pytest.fixture
-def mock_entry_points() -> Generator[Any, None, None]:
-    """Patch entry_points and importlib.resources to use mock-pkg manifest.
-
-    ``container.py`` resolves the manifest via::
-
-        pkg_manifest = files(plugin.name.replace("-", "_")) / plugin.value
-        with as_file(pkg_manifest) as manifest_path: ...
-
-    We mock ``files()`` to return the mock_pkg directory (a real ``Path``)
-    and ``as_file`` to be a no-op context manager yielding the path as-is.
-    """
-    ep = _make_mock_entry_point()
-
-    def mock_files(package: str) -> Path:
-        return _MOCK_PKG_DIR
-
-    @contextlib.contextmanager
-    def mock_as_file(path: Any) -> Generator[Path, None, None]:
-        yield Path(path) if not isinstance(path, Path) else path
-
-    with (
-        mock.patch(
-            "redsun.containers.container.entry_points",
-            return_value=[ep],
-        ),
-        mock.patch(
-            "redsun.containers.container.files",
-            side_effect=mock_files,
-        ),
-        mock.patch(
-            "redsun.containers.container.as_file",
-            side_effect=mock_as_file,
-        ),
-    ):
-        yield

--- a/tests/mock_pkg/redsun.yaml
+++ b/tests/mock_pkg/redsun.yaml
@@ -1,21 +1,12 @@
 devices:
-  my_motor:
-    class: mock_pkg.device:MyMotor
-  my_other_motor:
-    class: mock_pkg.device:NonDerivedMotor
-  my_detector:
-    class: mock_pkg.device:MockDetector
-  my_other_detector:
-    class: mock_pkg.device:NonDerivedDetector
-  my_broken_model:
-    class: mock_pkg.device:BrokenDevice
-  my_hidden_model:
-    class: mock_pkg.device.hidden:HiddenModel
+  my_motor: mock_pkg.device:MyMotor
+  my_other_motor: mock_pkg.device:NonDerivedMotor
+  my_detector: mock_pkg.device:MockDetector
+  my_other_detector: mock_pkg.device:NonDerivedDetector
+  my_broken_model: mock_pkg.device:BrokenDevice
+  my_hidden_model: mock_pkg.device.hidden:HiddenModel
 presenters:
-  my_controller:
-    class: mock_pkg.controller:MockController
-  broken_controller:
-    class: mock_pkg.controller:BrokenController
+  my_controller: mock_pkg.controller:MockController
+  broken_controller: mock_pkg.controller:BrokenController
 views:
-  mock_view:
-    class: mock_pkg.view:MockQtView
+  mock_view: mock_pkg.view:MockQtView

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
@@ -206,19 +205,30 @@ class TestFromConfig:
     """Tests for YAML-based dynamic container creation."""
 
     def test_from_config_motor(
-        self, mock_entry_points: Any, config_path: Path
+        self, config_path: Path
     ) -> None:
         container = AppContainer.from_config(
             str(config_path / "mock_motor_config.yaml")
         )
         assert not container.is_built
         assert container.config["frontend"] == "pyqt"
+        assert len(container._device_components) == 2
 
+    @pytest.mark.skipif(
+        not __import__("os").environ.get("DISPLAY"),
+        reason="requires a display (Qt)",
+    )
+    def test_from_config_motor_build(
+        self, config_path: Path
+    ) -> None:
+        container = AppContainer.from_config(
+            str(config_path / "mock_motor_config.yaml")
+        )
         container.build()
         assert len(container.devices) == 2
 
     def test_from_config_returns_qt_container(
-        self, mock_entry_points: Any, config_path: Path
+        self, config_path: Path
     ) -> None:
         from redsun.qt import QtAppContainer
 
@@ -228,7 +238,19 @@ class TestFromConfig:
         assert isinstance(container, QtAppContainer)
 
     def test_from_config_controller(
-        self, mock_entry_points: Any, config_path: Path
+        self, config_path: Path
+    ) -> None:
+        container = AppContainer.from_config(
+            str(config_path / "mock_controller_config.yaml")
+        )
+        assert len(container._presenter_components) == 1
+
+    @pytest.mark.skipif(
+        not __import__("os").environ.get("DISPLAY"),
+        reason="requires a display (Qt)",
+    )
+    def test_from_config_controller_build(
+        self, config_path: Path
     ) -> None:
         container = AppContainer.from_config(
             str(config_path / "mock_controller_config.yaml")
@@ -237,7 +259,7 @@ class TestFromConfig:
         assert len(container.presenters) == 1
 
     def test_from_config_unknown_frontend_raises(
-        self, mock_entry_points: Any, config_path: Path, tmp_path: Path
+        self, config_path: Path, tmp_path: Path
     ) -> None:
         import yaml
 


### PR DESCRIPTION
## Changes

**Manifest format** (`redsun.yaml`): each entry is now a flat `"module:ClassName"` string instead of `{class: "module:ClassName", ...}`.

**User config format**: `plugin_name`/`plugin_id` indirection is gone — each component entry carries a `class: "module:ClassName"` key directly alongside its kwargs:
```yaml
devices:
  camera:
    class: mypackage.devices:Camera
    exposure: 100.0
```

**`_load_plugins`**: drops the entire `entry_points` → manifest file → `plugin_id` lookup chain. Now imports the class directly via `importlib.import_module` from the `class` key.

**Dead code removed**: `ManifestItems`, `_PLUGIN_META_KEYS`, `entry_points`/`as_file`/`files` imports, `@overload` stubs on `_check_plugin_protocol`, `_assert_never`.

**`conftest.py`**: `mock_entry_points` fixture removed — no longer needed since `mock_pkg` is on `sys.path` and classes are imported directly.