### PR TITLE
Simplify plugin manifest format to flat class path strings

### DIFF
--- a/src/redsun/containers/container.py
+++ b/src/redsun/containers/container.py
@@ -596,13 +596,7 @@ class AppContainer(metaclass=AppContainerMeta):
 
                 class_path = items[plugin_id]
                 try:
-                    if isinstance(class_path, dict):
-                        # old-style manifest: {class: "module:Type", ...}
-                        dotted = class_path["class"]
-                    else:
-                        # new-style manifest: plain "module:Type" string
-                        dotted = class_path
-                    class_item_module, class_item_type = dotted.split(":")
+                    class_item_module, class_item_type = class_path.split(":")
                     imported_class = getattr(
                         import_module(class_item_module), class_item_type
                     )

--- a/tests/mock_pkg/redsun.yaml
+++ b/tests/mock_pkg/redsun.yaml
@@ -1,21 +1,12 @@
 devices:
-  my_motor:
-    class: mock_pkg.device:MyMotor
-  my_other_motor:
-    class: mock_pkg.device:NonDerivedMotor
-  my_detector:
-    class: mock_pkg.device:MockDetector
-  my_other_detector:
-    class: mock_pkg.device:NonDerivedDetector
-  my_broken_model:
-    class: mock_pkg.device:BrokenDevice
-  my_hidden_model:
-    class: mock_pkg.device.hidden:HiddenModel
+  my_motor: mock_pkg.device:MyMotor
+  my_other_motor: mock_pkg.device:NonDerivedMotor
+  my_detector: mock_pkg.device:MockDetector
+  my_other_detector: mock_pkg.device:NonDerivedDetector
+  my_broken_model: mock_pkg.device:BrokenDevice
+  my_hidden_model: mock_pkg.device.hidden:HiddenModel
 presenters:
-  my_controller:
-    class: mock_pkg.controller:MockController
-  broken_controller:
-    class: mock_pkg.controller:BrokenController
+  my_controller: mock_pkg.controller:MockController
+  broken_controller: mock_pkg.controller:BrokenController
 views:
-  mock_view:
-    class: mock_pkg.view:MockQtView
+  mock_view: mock_pkg.view:MockQtView


### PR DESCRIPTION
Plugin-published manifests (`redsun.yaml`) now use a flat string value instead of a `{class: ...}` dict:

**Before:**
```yaml
devices:
  device-id:
    class: module.path:ClassName
```

**After:**
```yaml
devices:
  device-id: module.path:ClassName
```

User config files are **unchanged** — `plugin_name`/`plugin_id` lookup still works exactly as before. The only code change is in `_load_plugins`, which now reads the manifest value directly as a string instead of extracting a `class` key from a dict.