### PR TITLE
fix: add an helper address `SyncOrAsync` and remove `attrs` support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ dev = [
     "ruff>=0.14.14",
     "ophyd>=1.11.0",
     "griffe-fieldz>=0.4.0",
-    "attrs>=25.4.0",
     "ophyd-async>=0.12.3",
     "pytest-asyncio>=1.3.0",
 ]

--- a/src/redsun/device/_acquisition.py
+++ b/src/redsun/device/_acquisition.py
@@ -252,11 +252,18 @@ class ControllableDataWriter(DataWriter, Protocol):
     devices into a single store and whose write location can be set by a
     presenter before each acquisition.
 
-    The wider ``get_indices_written(name=None)`` and
-    ``observe_indices_written(timeout, *, name=None)`` signatures live on
-    the concrete class; they satisfy [`DataWriter`][redsun.device.DataWriter]'s
-    narrower protocol structurally without being redeclared here.
+    The wider ``get_indices_written(name=None)`` signature takes an optional
+    *name* argument identifying which source to query (the narrower
+    [`DataWriter`][redsun.device.DataWriter] protocol does not accept it, but
+    multi-source backends need it).
     """
+
+    def get_indices_written(
+        self,
+        name: str | None = None,
+    ) -> SyncOrAsync[int]:
+        """Return the number of indices written for *name* (or globally if ``None``)."""
+        ...
 
     def register(
         self,

--- a/src/redsun/storage/protocols.py
+++ b/src/redsun/storage/protocols.py
@@ -27,14 +27,19 @@ class HasWriterLogic(Protocol):
     """
 
     @property
-    def writer_logic(self) -> DataWriter:
-        """Return the writer logic associated with this device.
+    def writer_logic(self) -> DataWriter | None:
+        """Return the writer logic associated with this device, or ``None``.
+
+        ``None`` indicates the writer has not yet been injected (e.g. in
+        headless or test scenarios).  Callers should check for ``None``
+        before using the writer.
 
         Returns
         -------
-        DataWriter
-            The storage writer paired with this device.  May implement the
-            richer [`ControllableDataWriter`][redsun.device.ControllableDataWriter]
+        DataWriter | None
+            The storage writer paired with this device, or ``None``.  May
+            implement the richer
+            [`ControllableDataWriter`][redsun.device.ControllableDataWriter]
             interface if the backend supports multi-source writes.
         """
         ...

--- a/src/redsun/utils/__init__.py
+++ b/src/redsun/utils/__init__.py
@@ -9,14 +9,13 @@ from __future__ import annotations
 
 import asyncio
 import inspect
-from typing import TYPE_CHECKING, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, overload
 
 from redsun.engine import get_shared_loop
 
 if TYPE_CHECKING:
-    from collections.abc import Coroutine, Iterable
+    from collections.abc import Awaitable, Iterable
     from concurrent.futures import Future
-    from typing import Any
 
     from psygnal import SignalInstance
 
@@ -67,17 +66,21 @@ def find_signals(
     return result
 
 
-def resolve_sync_or_async(value: T | Coroutine[Any, Any, T]) -> T:
+@overload
+def resolve_sync_or_async(value: Awaitable[T]) -> T: ...
+@overload
+def resolve_sync_or_async(value: T) -> T: ...
+def resolve_sync_or_async(value: Any) -> Any:
     """Resolve a ``SyncOrAsync[T]`` value to its concrete ``T``.
 
     If *value* is not a coroutine it is returned directly. If it is,
-    it will submitted to the global shared event loop running
+    it will be submitted to the global shared event loop running
     in a background thread.
 
     Parameters
     ----------
     value :
-        Either a plain value ``T`` or an ``Awaitable[T]``.
+        Either a plain value ``T`` or a ``Coroutine[Any, Any, T]``.
 
     Returns
     -------
@@ -86,6 +89,6 @@ def resolve_sync_or_async(value: T | Coroutine[Any, Any, T]) -> T:
     """
     if inspect.iscoroutine(value):
         loop = get_shared_loop()
-        future: Future[T] = asyncio.run_coroutine_threadsafe(value, loop)
+        future: Future[Any] = asyncio.run_coroutine_threadsafe(value, loop)
         return future.result()
-    return cast("T", value)
+    return value

--- a/src/redsun/utils/__init__.py
+++ b/src/redsun/utils/__init__.py
@@ -1,15 +1,22 @@
 """General-purpose utilities for redsun.
 
-Currently exposes `find_signals`, a helper for locating named signals
-in a `VirtualContainer` without needing to know the owner's instance name.
+Exposes:
+- `find_signals` — locate named signals in a `VirtualContainer`.
+- `resolve_sync_or_async` — resolve a ``SyncOrAsync[T]`` value to ``T``.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import asyncio
+import inspect
+from typing import TYPE_CHECKING, TypeVar, cast
+
+from redsun.engine import get_shared_loop
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Coroutine, Iterable
+    from concurrent.futures import Future
+    from typing import Any
 
     from psygnal import SignalInstance
 
@@ -17,7 +24,11 @@ if TYPE_CHECKING:
 
 __all__ = [
     "find_signals",
+    "resolve_sync_or_async",
 ]
+
+
+T = TypeVar("T")
 
 
 def find_signals(
@@ -54,3 +65,27 @@ def find_signals(
         if not remaining:
             break
     return result
+
+
+def resolve_sync_or_async(value: T | Coroutine[Any, Any, T]) -> T:
+    """Resolve a ``SyncOrAsync[T]`` value to its concrete ``T``.
+
+    If *value* is not a coroutine it is returned directly. If it is,
+    it will submitted to the global shared event loop running
+    in a background thread.
+
+    Parameters
+    ----------
+    value :
+        Either a plain value ``T`` or an ``Awaitable[T]``.
+
+    Returns
+    -------
+    T
+        The resolved value.
+    """
+    if inspect.iscoroutine(value):
+        loop = get_shared_loop()
+        future: Future[T] = asyncio.run_coroutine_threadsafe(value, loop)
+        return future.result()
+    return cast("T", value)

--- a/tests/container/mock_pkg/device/hidden/hidden_model.py
+++ b/tests/container/mock_pkg/device/hidden/hidden_model.py
@@ -1,18 +1,12 @@
-from typing import Any
+from __future__ import annotations
 
-from attrs import define
+from typing import Any
 
 from redsun.device import Device
 
 
-@define(kw_only=True)
 class HiddenModel(Device):
     """Hidden model for testing nested module discovery."""
 
     def __init__(self, name: str, /, **kwargs: Any) -> None:
-        super().__init__(name)
-        self.__attrs_init__(**kwargs)
-
-    @property
-    def parent(self) -> None:
-        return None
+        super().__init__(name, **kwargs)

--- a/tests/container/mock_pkg/device/mock_detectors.py
+++ b/tests/container/mock_pkg/device/mock_detectors.py
@@ -1,9 +1,8 @@
-from attrs import define, setters
+from __future__ import annotations
 
 from redsun.device import Device, SoftAttrR, SoftAttrRW
 
 
-@define(kw_only=True, slots=False, on_setattr=setters.NO_OP)
 class MockDetector(Device):
     """Mock detector device.
 
@@ -12,13 +11,6 @@ class MockDetector(Device):
     is embedded in its descriptor (``units`` field) rather than exposed as a
     separate signal.
     """
-
-    exposure: SoftAttrRW[float]
-    sensor_shape: SoftAttrR[tuple[int, int]]
-    pixel_size: SoftAttrR[tuple[float, float, float]]
-    integer: SoftAttrRW[int]
-    floating: SoftAttrRW[float]
-    string: SoftAttrRW[str]
 
     def __init__(
         self,
@@ -34,21 +26,18 @@ class MockDetector(Device):
         string: str = "",
     ) -> None:
         super().__init__(name)
-        self.__attrs_init__(
-            exposure=SoftAttrRW[float](exposure, units=egu),
-            sensor_shape=SoftAttrR[tuple[int, int]](
-                tuple(sensor_shape),  # type: ignore[arg-type]
-            ),
-            pixel_size=SoftAttrR[tuple[float, float, float]](
-                tuple(pixel_size),  # type: ignore[arg-type]
-            ),
-            integer=SoftAttrRW[int](integer),
-            floating=SoftAttrRW[float](floating),
-            string=SoftAttrRW[str](string),
+        self.exposure = SoftAttrRW[float](exposure, units=egu)
+        self.sensor_shape = SoftAttrR[tuple[int, int]](
+            tuple(sensor_shape),  # type: ignore[arg-type]
         )
+        self.pixel_size = SoftAttrR[tuple[float, float, float]](
+            tuple(pixel_size),  # type: ignore[arg-type]
+        )
+        self.integer = SoftAttrRW[int](integer)
+        self.floating = SoftAttrRW[float](floating)
+        self.string = SoftAttrRW[str](string)
 
 
-@define(kw_only=True, slots=False, on_setattr=setters.NO_OP)
 class MockDetectorWithStorage(MockDetector):
     """Mock detector that declares storage capability via ``storage_info()``."""
 
@@ -56,16 +45,12 @@ class MockDetectorWithStorage(MockDetector):
         super().__init__(name, **kwargs)
 
 
-@define(kw_only=True, slots=False)
 class NonDerivedDetector:
-    """Mock non-derived detector for structural protocol testing."""
+    """Mock non-derived detector for structural protocol testing.
 
-    exposure: SoftAttrRW[float]
-    sensor_shape: SoftAttrR[tuple[int, int]]
-    pixel_size: SoftAttrR[tuple[float, float, float]]
-    integer: SoftAttrRW[int]
-    floating: SoftAttrRW[float]
-    string: SoftAttrRW[str]
+    Not a [`Device`][redsun.device.Device] subclass — used to verify that
+    structural protocols are satisfied purely by duck typing.
+    """
 
     def __init__(
         self,
@@ -81,20 +66,18 @@ class NonDerivedDetector:
         string: str = "",
     ) -> None:
         self._name = name
-        self.__attrs_init__(
-            exposure=SoftAttrRW[float](exposure, name=f"{name}-exposure", units=egu),
-            sensor_shape=SoftAttrR[tuple[int, int]](
-                tuple(sensor_shape),  # type: ignore[arg-type]
-                name=f"{name}-sensor_shape",
-            ),
-            pixel_size=SoftAttrR[tuple[float, float, float]](
-                tuple(pixel_size),  # type: ignore[arg-type]
-                name=f"{name}-pixel_size",
-            ),
-            integer=SoftAttrRW[int](integer, name=f"{name}-integer"),
-            floating=SoftAttrRW[float](floating, name=f"{name}-floating"),
-            string=SoftAttrRW[str](string, name=f"{name}-string"),
+        self.exposure = SoftAttrRW[float](exposure, name=f"{name}-exposure", units=egu)
+        self.sensor_shape = SoftAttrR[tuple[int, int]](
+            tuple(sensor_shape),  # type: ignore[arg-type]
+            name=f"{name}-sensor_shape",
         )
+        self.pixel_size = SoftAttrR[tuple[float, float, float]](
+            tuple(pixel_size),  # type: ignore[arg-type]
+            name=f"{name}-pixel_size",
+        )
+        self.integer = SoftAttrRW[int](integer, name=f"{name}-integer")
+        self.floating = SoftAttrRW[float](floating, name=f"{name}-floating")
+        self.string = SoftAttrRW[str](string, name=f"{name}-string")
 
     @property
     def parent(self) -> None:

--- a/tests/container/mock_pkg/device/mock_motors.py
+++ b/tests/container/mock_pkg/device/mock_motors.py
@@ -1,13 +1,12 @@
-from typing import Literal
+from __future__ import annotations
 
-from attrs import define, setters
+from typing import Literal
 
 from redsun.device import Device, SoftAttrR, SoftAttrRW
 
 Axis = Literal["X", "Y", "Z"]
 
 
-@define(kw_only=True, slots=False, on_setattr=setters.NO_OP)
 class MyMotor(Device):
     """Mock motor device.
 
@@ -16,12 +15,6 @@ class MyMotor(Device):
     is embedded in the ``step_size`` descriptor (``units`` field) rather
     than exposed as a separate signal.
     """
-
-    axis: SoftAttrR[list[Axis]]
-    step_size: SoftAttrRW[dict[Axis, float]]
-    integer: SoftAttrRW[int]
-    floating: SoftAttrRW[float]
-    string: SoftAttrRW[str]
 
     def __init__(
         self,
@@ -38,24 +31,15 @@ class MyMotor(Device):
         super().__init__(name)
         _axis: list[Axis] = axis or ["X"]
         _step_size: dict[Axis, float] = step_size or {ax: 0.1 for ax in _axis}
-        self.__attrs_init__(
-            axis=SoftAttrR[list[Axis]](_axis),
-            step_size=SoftAttrRW[dict[Axis, float]](_step_size, units=egu),
-            integer=SoftAttrRW[int](integer),
-            floating=SoftAttrRW[float](floating),
-            string=SoftAttrRW[str](string),
-        )
+        self.axis = SoftAttrR[list[Axis]](_axis)
+        self.step_size = SoftAttrRW[dict[Axis, float]](_step_size, units=egu)
+        self.integer = SoftAttrRW[int](integer)
+        self.floating = SoftAttrRW[float](floating)
+        self.string = SoftAttrRW[str](string)
 
 
-@define(kw_only=True, slots=False)
 class NonDerivedMotor:
     """Mock non-derived motor for structural protocol testing."""
-
-    axis: SoftAttrR[list[Axis]]
-    step_size: SoftAttrRW[dict[Axis, float]]
-    integer: SoftAttrRW[int]
-    floating: SoftAttrRW[float]
-    string: SoftAttrRW[str]
 
     def __init__(
         self,
@@ -72,15 +56,13 @@ class NonDerivedMotor:
         self._name = name
         _axis: list[Axis] = axis or ["X"]
         _step_size: dict[Axis, float] = step_size or {ax: 0.1 for ax in _axis}
-        self.__attrs_init__(
-            axis=SoftAttrR[list[Axis]](_axis, name=f"{name}-axis"),
-            step_size=SoftAttrRW[dict[Axis, float]](
-                _step_size, name=f"{name}-step_size", units=egu
-            ),
-            integer=SoftAttrRW[int](integer, name=f"{name}-integer"),
-            floating=SoftAttrRW[float](floating, name=f"{name}-floating"),
-            string=SoftAttrRW[str](string, name=f"{name}-string"),
+        self.axis = SoftAttrR[list[Axis]](_axis, name=f"{name}-axis")
+        self.step_size = SoftAttrRW[dict[Axis, float]](
+            _step_size, name=f"{name}-step_size", units=egu
         )
+        self.integer = SoftAttrRW[int](integer, name=f"{name}-integer")
+        self.floating = SoftAttrRW[float](floating, name=f"{name}-floating")
+        self.string = SoftAttrRW[str](string, name=f"{name}-string")
 
     @property
     def parent(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2036,7 +2036,6 @@ zarr = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "attrs" },
     { name = "griffe-fieldz" },
     { name = "mypy" },
     { name = "ophyd" },
@@ -2077,7 +2076,6 @@ provides-extras = ["pyqt", "pyside", "zarr"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "attrs", specifier = ">=25.4.0" },
     { name = "griffe-fieldz", specifier = ">=0.4.0" },
     { name = "mypy", specifier = ">=1.20.0" },
     { name = "ophyd", specifier = ">=1.11.0" },


### PR DESCRIPTION
`attrs` support was flaky at best and not worthwhile - it's better used for an alternative to dataclasses anyway.