### PR TITLE
feat(aio): culsans-backed psygnal async backend

### DIFF
--- a/.claude/skills/docs-conventions/SKILL.md
+++ b/.claude/skills/docs-conventions/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: docs-conventions
+description: Conventions for writing and updating docs under docs/ — Diataxis structure, ADR recording, and mkdocstrings pitfalls. Use when adding or editing documentation, or when a public API change needs its reference updated.
+---
+
+# Docs conventions
+
+- Diataxis under `docs/`: `tutorials/` (learning), `how-to/` (task),
+  `explanation/` (rationale), `reference/api/` (mkdocstrings-generated facts).
+- One authoritative source per fact; cross-link instead of restating.
+- Material-style admonitions (`!!! warning`), mermaid fences for diagrams.
+- Reference pages are generated from docstrings — fix the docstring, not the
+  `.md`, when reference content is wrong.
+- Architectural decisions are recorded as ADRs under
+  `docs/explanation/decisions/` (numbered, `COPYME` template — same
+  convention as ophyd-async). Architecture changes get a new ADR; superseded
+  ADRs are marked, not edited. Wire new ADRs into the `zensical.toml` nav and
+  `docs/explanation/index.md`.
+- **A green `zensical build` does not mean the docs are correct.** Broken
+  mkdocstrings xrefs do not fail the build. When changing public API, grep
+  `docs/` for the old symbol name and fix references by hand.
+
+Build the docs with `uv run zensical build`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,27 +2,14 @@
 
 Single source of conventions for agents (Claude, Copilot) and contributors — cross-link, don't duplicate.
 
-## Repository layout
+Things the tree does not show:
 
-```
-src/redsun/
-  virtual/       # VirtualContainer: DI + psygnal signal bus + document callbacks
-  containers/    # AppContainer, build phases, YAML config, plugin discovery
-                 #   qt/ — Qt-specific container + main view
-  device/        # device protocols (HasAsyncShutdown); DeviceMap comes from ophyd-async
-  engine/        # RunEngine wrapper, actions, plan stubs, exceptions
-  presenter/     # Presenter ABC, plan_spec, utils; builtins (StoragePresenter)
-  view/          # View base; qt/ — widget factory, treeview, sequence edit
-  storage/       # BaseStorage/SinkFactory, FrameSink, registry, path provider, FrameRouter
-                 #   backends/ — _memory, _acquire_zarr
-  common/ utils/ aio.py log.py
-docs/            # zensical + mkdocstrings, Diataxis (see below)
-benchmarks/      # storage performance benchmarks — not tests, sdist-only
-                 #   run: uv run python benchmarks/bench_acquire_zarr.py
-tests/sdk/       # per-subsystem unit tests
-tests/container/ # container build/plugin-discovery tests + mock_pkg fixtures
-pyproject.toml   # all tool config: pytest, ruff, mypy, coverage
-```
+- `src/redsun/device/` holds device protocols only — `DeviceMap` comes from
+  ophyd-async, not from this package.
+- `benchmarks/` are not tests and are never collected by pytest; they ship in
+  the sdist only. Run one with
+  `uv run python benchmarks/bench_acquire_zarr.py`.
+- `pyproject.toml` carries all tool config: pytest, ruff, mypy, coverage.
 
 ## Build & validate
 
@@ -145,20 +132,8 @@ uv run zensical build                   # docs
 
 ## Docs conventions
 
-- Diataxis under `docs/`: `tutorials/` (learning), `how-to/` (task),
-  `explanation/` (rationale), `reference/api/` (mkdocstrings-generated facts).
-- One authoritative source per fact; cross-link instead of restating.
-- Material-style admonitions (`!!! warning`), mermaid fences for diagrams.
-- Reference pages are generated from docstrings — fix the docstring, not the
-  `.md`, when reference content is wrong.
-- Architectural decisions are recorded as ADRs under
-  `docs/explanation/decisions/` (numbered, `COPYME` template — same
-  convention as ophyd-async). Architecture changes get a new ADR; superseded
-  ADRs are marked, not edited. Wire new ADRs into the `zensical.toml` nav and
-  `docs/explanation/index.md`.
-- **A green `zensical build` does not mean the docs are correct.** Broken
-  mkdocstrings xrefs do not fail the build. When changing public API, grep
-  `docs/` for the old symbol name and fix references by hand.
+See the `docs-conventions` skill — Diataxis layout, ADR recording, and the
+mkdocstrings pitfalls that a green `zensical build` will not catch.
 
 ## Response style (agents)
 

--- a/docs/explanation/decisions/0005-culsans-psygnal-async-backend.md
+++ b/docs/explanation/decisions/0005-culsans-psygnal-async-backend.md
@@ -1,0 +1,85 @@
+# 5. Culsans-backed psygnal async backend
+
+Date: 2026-07-26
+
+## Status
+
+Accepted
+
+## Context
+
+Redsun's UI runs on the Qt main thread while device logic runs on a single
+background `asyncio` loop. A view emits a signal; a presenter reacts to it by
+awaiting hardware. psygnal already supports this shape directly — connecting a
+coroutine function to a signal builds a coroutine callback that hands the call
+to whatever async backend is installed — so no bridging code of our own is
+needed at the call sites.
+
+The stock backends could not carry that traffic:
+
+- `AsyncioBackend.put` is `asyncio.Queue.put_nowait`, which is not thread-safe.
+  Called from the Qt thread while the background loop sits idle, the queue's
+  internal `call_soon` never wakes the parked loop: a signal emitted from the
+  GUI was measured as undelivered after five seconds. A thread-safe hand-off
+  delivers the same emission in well under a millisecond.
+- `asyncio.Queue` binds to the loop that first awaits it while empty. The
+  backend outlives any single loop — it is created once and lives for the
+  process — so a queue bound to one loop raises once another is running, which
+  is exactly what pytest's per-test event loops produce.
+
+psygnal's `set_async_backend()` accepts only the three literal names
+`"asyncio"`, `"anyio"`, and `"trio"`, so there is no public API for selecting a
+backend of our own. Its teardown helper, `clear_async_backend()`, dispatches on
+`isinstance` against the three concrete backend classes to decide whether to
+close the queue.
+
+## Decision
+
+`redsun.aio.CulsansAsyncioBackend` implements psygnal's backend contract on a
+[culsans](https://pypi.org/project/culsans/) queue, which is thread-safe on the
+producing side by construction and is not bound to any one event loop. A drain
+coroutine runs on the shared loop and dispatches each queued callback as its
+own task, so a slow slot does not serialize the ones behind it.
+
+The class is wired into psygnal at two levels, and both are load-bearing:
+
+- It **inherits** `psygnal._async._AsyncBackend`, which supplies the abstract
+  contract and makes the instance assignable where psygnal expects a backend.
+  Virtual registration alone is invisible to a type checker.
+- It is **registered as a virtual subclass** of `AsyncioBackend`, because that
+  `isinstance` check is what makes `clear_async_backend()` call `close()`.
+  Without it the backend is dropped with its queue and drain task still live.
+
+Installation goes through `redsun.aio.set_async_backend()`, which assigns
+psygnal's module global directly — the only way to install a backend that
+`set_async_backend()` cannot name. It is idempotent and refuses to displace a
+backend it did not install. The backend reports its name as `"culsans"`, so
+psygnal's own setter raises rather than silently replacing it.
+
+`QtAppContainer` owns the lifecycle: `build()` installs the backend before the
+dependency-injection phase, since coroutine slots resolve a backend at connect
+time, and `shutdown()` hands teardown back to psygnal's `clear_async_backend()`.
+
+Exceptions raised inside a dispatched slot are logged on the `redsun` logger
+through a task done-callback. Nothing awaits these tasks, so an unhandled
+exception would otherwise surface only as asyncio's "task exception was never
+retrieved" at garbage-collection time, or not at all.
+
+## Consequences
+
+- Redsun depends on two private psygnal symbols: `_AsyncBackend` as a base
+  class and `_ASYNC_BACKEND` as the assignment target, plus
+  `WeakCallback.dereference()` reached through the inherited `call_back`. A
+  psygnal release that renames any of them breaks dispatch. The test suite
+  pins the observable behaviour — installation, teardown, and delivery — so
+  the break surfaces as a test failure rather than as silently dropped
+  signals.
+- culsans and aiologic become runtime dependencies. Both are pre-1.0.
+- Only `QtAppContainer` installs a backend. Under a bare `AppContainer`,
+  connecting a coroutine to a signal raises `RuntimeError` from psygnal.
+- A failing slot no longer propagates anywhere a caller can see: emitters
+  never learn that a slot raised, and the log is the only record.
+- `close()` is synchronous and returns before in-flight callbacks finish. It
+  shuts the queue down and lets the drain's exit path cancel outstanding
+  tasks; awaiting their completion would require an async teardown entry
+  point, which no caller has asked for yet.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -25,3 +25,4 @@ as [ophyd-async](https://blueskyproject.io/ophyd-async/main/explanations/decisio
 - **[2. Storage dual-context redesign](decisions/0002-storage-dual-context-redesign.md)**
 - **[3. Structural subtyping for presenters and views](decisions/0003-structural-subtyping-for-presenters-and-views.md)**
 - **[4. Owner-scoped signal lookup](decisions/0004-owner-scoped-signal-lookup.md)**
+- **[5. Culsans-backed psygnal async backend](decisions/0005-culsans-psygnal-async-backend.md)**

--- a/docs/reference/api/aio.md
+++ b/docs/reference/api/aio.md
@@ -1,0 +1,30 @@
+# Async runtime
+
+Design rationale:
+[ADR 0005](../../explanation/decisions/0005-culsans-psygnal-async-backend.md).
+
+## Running coroutines
+
+::: redsun.aio
+    options:
+      members:
+        - run_coro
+
+## Internal machinery
+
+!!! warning "Not part of the public API"
+
+    The symbols below are wired up by the application container at startup and
+    torn down on shutdown. They are documented so that the runtime's behaviour
+    is inspectable, not so that components call them: installing a second
+    backend, or building a loop alongside the shared one, breaks signal
+    dispatch for the whole process. Use [`run_coro`](#redsun.aio.run_coro) to
+    reach the shared loop.
+
+::: redsun.aio.get_shared_loop
+
+::: redsun.aio.set_async_backend
+
+::: redsun.aio.CulsansAsyncioBackend
+
+::: redsun.aio.AwaitableEvent

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are specified in the format `DD-MM-YYYY`.
 
-## [0.10.0]
+## [Unreleased]
+
+### Added
+
+- `redsun.aio.set_async_backend()` — installs `CulsansAsyncioBackend` as psygnal's
+  active async backend, so coroutines connected to a signal are dispatched onto the
+  shared event loop from any thread. Idempotent; raises if a different backend is
+  already active. Tear it down with psygnal's `clear_async_backend()`.
+  `QtAppContainer` calls it in `build()` and clears it in `shutdown()` (ADR 0005).
+- `CulsansAsyncioBackend` and `AwaitableEvent` (`redsun.aio`) — the backend itself and
+  the resettable, awaitable event it reports `running` through. Exceptions raised by a
+  dispatched slot are logged on the `redsun` logger instead of being discarded.
+
+### Changed (breaking)
+
+- `get_shared_loop()` is no longer re-exported from `redsun.engine`; import it from
+  `redsun.aio`, where it is defined. It is the only piece of the async runtime
+  intended for use outside the application container, alongside `run_coro()`.
+
+## [0.10.0] 25-07-2026
 
 ### Added
 

--- a/src/redsun/aio.py
+++ b/src/redsun/aio.py
@@ -1,15 +1,65 @@
+"""Shared background event loop and dispatch of coroutines connected to signals.
+
+Redsun runs one background `asyncio` event loop for the whole process. Device
+I/O and any coroutine connected to a psygnal signal execute there, off the GUI
+thread that emits.
+
+Only `run_coro` is meant for general use: it is how synchronous code — a
+presenter method, a Qt slot — runs a coroutine on that loop and gets its
+result. Everything else in this module is application plumbing, set up by the
+application container during startup and torn down on shutdown. Components
+should not build a loop or install a backend of their own.
+"""
+
 from __future__ import annotations
 
 import asyncio
 from threading import Thread
 from typing import TYPE_CHECKING, ClassVar, TypeVar, overload
 
+import aiologic as aiol
+import psygnal._async
 from bluesky.run_engine import _ensure_event_loop_running
+from culsans import Queue, QueueShutDown
+from psygnal import get_async_backend
+from psygnal._async import AsyncioBackend, _AsyncBackend
+
+from redsun.log import Loggable
 
 if TYPE_CHECKING:
     from collections.abc import Coroutine
     from concurrent.futures import Future
     from typing import Any, Literal
+
+    from psygnal._async import QueueItem
+
+
+class AwaitableEvent:
+    """Resettable event whose ``wait`` is a coroutine.
+
+    Wraps `aiologic.REvent` so that the event can be set and cleared from any
+    thread while still being awaited from a coroutine.
+    """
+
+    def __init__(self) -> None:
+        self._event = aiol.REvent()
+
+    def is_set(self) -> bool:
+        """Return ``True`` if the event is set."""
+        return self._event.is_set()
+
+    def set(self) -> None:
+        """Set the event, waking every waiter."""
+        self._event.set()
+
+    def clear(self) -> None:
+        """Unset the event."""
+        self._event.clear()
+
+    async def wait(self) -> None:
+        """Wait until the event is set."""
+        await self._event
+
 
 R = TypeVar("R")
 
@@ -43,8 +93,8 @@ class _LoopFactory:
         return self()
 
 
-_loop_factory = _LoopFactory()
 #: Global factory for shared background event loop. Not public.
+_loop_factory = _LoopFactory()
 
 
 def get_shared_loop() -> asyncio.AbstractEventLoop:
@@ -56,6 +106,107 @@ def get_shared_loop() -> asyncio.AbstractEventLoop:
         The shared event loop.
     """
     return _loop_factory()
+
+
+class CulsansAsyncioBackend(_AsyncBackend, Loggable):
+    """Psygnal async backend draining a culsans queue on the shared loop.
+
+    Queued callbacks are dispatched as tasks on the loop returned by
+    `get_shared_loop`, so signals emitted from any thread are delivered.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("culsans")
+        self._queue: Queue[QueueItem] = Queue()
+        self._running = AwaitableEvent()
+        self._tasks: set[asyncio.Task[None]] = set()
+        self._run_task = asyncio.run_coroutine_threadsafe(self.run(), get_shared_loop())
+
+    @property
+    def running(self) -> AwaitableEvent:
+        """Return the event indicating if the backend is running."""
+        return self._running
+
+    def put(self, item: QueueItem) -> None:
+        """Queue a callback for dispatch on the shared loop."""
+        self._queue.put_nowait(item)
+
+    def close(self) -> None:
+        """Shut the queue down; the drain cancels outstanding callbacks."""
+        self._queue.shutdown()
+
+    async def run(self) -> None:
+        """Drain the queue until it is shut down or the drain is cancelled."""
+        if self._running.is_set():
+            return
+        self._running.set()
+        try:
+            loop = get_shared_loop()
+            while True:
+                item = await self._queue.async_get()
+                task = loop.create_task(self.call_back(item))
+                self._tasks.add(task)
+                task.add_done_callback(self._tasks.discard)
+                task.add_done_callback(self._log_slot_exception)
+        except asyncio.CancelledError:
+            self.logger.debug("Dispatch cancelled")
+        except QueueShutDown:
+            self.logger.debug("Dispatch queue shut down")
+        except Exception as e:
+            self.logger.error(f"Dispatch stopped: {e}", exc_info=e)
+        finally:
+            self._running.clear()
+            for task in self._tasks:
+                task.cancel()
+
+    def _log_slot_exception(self, task: asyncio.Task[None]) -> None:
+        """Report an exception raised by a slot, which nothing else awaits."""
+        if task.cancelled():
+            return
+        if (exc := task.exception()) is not None:
+            self.logger.error(f"Exception in async slot: {exc}", exc_info=exc)
+
+    @property
+    def name(self) -> str:
+        """Name of the backend, for logging and debugging purposes."""
+        return f"psygnal-{self._backend}"
+
+
+# psygnal discriminates on `isinstance(..., AsyncioBackend)` when tearing a
+# backend down; without this registration `clear_async_backend()` would drop
+# this backend without ever calling `close()`.
+AsyncioBackend.register(CulsansAsyncioBackend)
+
+
+def set_async_backend() -> CulsansAsyncioBackend:
+    """Install the culsans backend as psygnal's active async backend.
+
+    Must be called before connecting a coroutine to a signal. Calling it
+    again returns the backend installed by the first call; tear it down with
+    psygnal's own ``clear_async_backend``.
+
+    Returns
+    -------
+    CulsansAsyncioBackend
+        The active backend.
+
+    Raises
+    ------
+    RuntimeError
+        If a different async backend is already active.
+    """
+    current = get_async_backend()
+    if isinstance(current, CulsansAsyncioBackend):
+        return current
+    if current is not None:
+        raise RuntimeError(f"Async backend already set to: {current._backend}")
+
+    backend = CulsansAsyncioBackend()
+
+    # psygnal resolves the active backend through its own module global, so
+    # binding a name here is not enough for `get_async_backend()` to find it
+    psygnal._async._ASYNC_BACKEND = backend
+    return backend
 
 
 @overload
@@ -88,6 +239,9 @@ def run_coro(
 
 
 __all__ = [
+    "AwaitableEvent",
+    "CulsansAsyncioBackend",
     "get_shared_loop",
     "run_coro",
+    "set_async_backend",
 ]

--- a/src/redsun/aio.py
+++ b/src/redsun/aio.py
@@ -119,12 +119,19 @@ class CulsansAsyncioBackend(_AsyncBackend, Loggable):
         super().__init__("culsans")
         self._queue: Queue[QueueItem] = Queue()
         self._running = AwaitableEvent()
+        self._draining = False
         self._tasks: set[asyncio.Task[None]] = set()
+
+        # the queue holds callbacks from here on, so work queued before the
+        # loop thread picks the drain up is still delivered; marking the
+        # backend running only once the drain executes would expose a window
+        # in which callers see it as inert when it is not
+        self._running.set()
         self._run_task = asyncio.run_coroutine_threadsafe(self.run(), get_shared_loop())
 
     @property
     def running(self) -> AwaitableEvent:
-        """Return the event indicating if the backend is running."""
+        """Return the event indicating whether the backend accepts callbacks."""
         return self._running
 
     def put(self, item: QueueItem) -> None:
@@ -137,9 +144,9 @@ class CulsansAsyncioBackend(_AsyncBackend, Loggable):
 
     async def run(self) -> None:
         """Drain the queue until it is shut down or the drain is cancelled."""
-        if self._running.is_set():
+        if self._draining:
             return
-        self._running.set()
+        self._draining = True
         try:
             loop = get_shared_loop()
             while True:
@@ -155,6 +162,7 @@ class CulsansAsyncioBackend(_AsyncBackend, Loggable):
         except Exception as e:
             self.logger.error(f"Dispatch stopped: {e}", exc_info=e)
         finally:
+            self._draining = False
             self._running.clear()
             for task in self._tasks:
                 task.cancel()

--- a/src/redsun/containers/qt/_container.py
+++ b/src/redsun/containers/qt/_container.py
@@ -6,9 +6,12 @@ import logging
 import sys
 from typing import TYPE_CHECKING, NoReturn, cast
 
+# psygnal re-exports get/set_async_backend at the top level but not this one
+from psygnal._async import clear_async_backend
 from psygnal.qt import start_emitting_from_queue
 from qtpy.QtWidgets import QApplication
 
+from redsun.aio import set_async_backend
 from redsun.containers.container import AppContainer
 from redsun.containers.qt._mainview import QtMainView
 
@@ -56,7 +59,7 @@ class QtAppContainer(AppContainer):
         return self._main_view
 
     def build(self) -> QtAppContainer:
-        """Ensure a ``QApplication`` exists, then build all components.
+        """Ensure a ``QApplication`` and an async backend exist, then build.
 
         If a ``QApplication`` is not yet running (e.g. when ``build()`` is
         called explicitly before ``run()``), one is created here so that
@@ -67,8 +70,16 @@ class QtAppContainer(AppContainer):
             self._qt_app = cast(
                 "QApplication", QApplication.instance() or QApplication(sys.argv)
             )
+        # coroutine slots resolve a backend when they are connected, which
+        # happens during the dependency injection phase of super().build()
+        set_async_backend()
         super().build()
         return self
+
+    def shutdown(self) -> None:
+        """Shut components down, then tear the async backend down."""
+        super().shutdown()
+        clear_async_backend()
 
     def run(self) -> NoReturn:
         """Build and launch the Qt application."""

--- a/src/redsun/engine/__init__.py
+++ b/src/redsun/engine/__init__.py
@@ -5,7 +5,6 @@ from bluesky.protocols import Status
 from ._wrapper import (
     RunEngine,
     RunEngineResult,
-    get_shared_loop,
     register_bound_command,
 )
 
@@ -13,6 +12,5 @@ __all__ = [
     "RunEngine",
     "RunEngineResult",
     "Status",
-    "get_shared_loop",
     "register_bound_command",
 ]

--- a/src/redsun/engine/_wrapper.py
+++ b/src/redsun/engine/_wrapper.py
@@ -33,7 +33,7 @@ def default_scan_id_source(md: dict[str, Any]) -> int:
     return scan_id + 1
 
 
-__all__ = ["RunEngine", "RunEngineResult", "get_shared_loop", "register_bound_command"]
+__all__ = ["RunEngine", "RunEngineResult", "register_bound_command"]
 
 REResultType = RunEngineResult | tuple[str, ...]
 

--- a/tests/container/configs/mock_async_config.yaml
+++ b/tests/container/configs/mock_async_config.yaml
@@ -1,0 +1,17 @@
+schema_version: 1.0
+frontend: pyqt
+session: mock-async-session
+devices:
+  my_motor:
+    plugin_name: mock-pkg
+    plugin_id: my_motor
+    egu: mm
+presenters:
+  motor_controller:
+    plugin_name: mock-pkg
+    plugin_id: async_motor_controller
+views:
+  motor_view:
+    plugin_name: mock-pkg
+    plugin_id: motor_view
+    motor: my_motor

--- a/tests/container/mock_pkg/controller/__init__.py
+++ b/tests/container/mock_pkg/controller/__init__.py
@@ -1,3 +1,3 @@
-from .mock_presenters import BrokenController, MockController
+from .mock_presenters import AsyncMotorController, BrokenController, MockController
 
-__all__ = ["BrokenController", "MockController"]
+__all__ = ["AsyncMotorController", "BrokenController", "MockController"]

--- a/tests/container/mock_pkg/controller/mock_presenters.py
+++ b/tests/container/mock_pkg/controller/mock_presenters.py
@@ -1,8 +1,17 @@
+from __future__ import annotations
+
+import asyncio
 from collections.abc import Mapping
+from typing import Any, cast
 
 from ophyd_async.core import Device
+from psygnal import Signal
 
 from redsun.presenter import Presenter
+from redsun.utils import find_signals
+from redsun.virtual import VirtualContainer
+
+from ..device import MyMotor
 
 
 class MockController(Presenter):
@@ -35,3 +44,44 @@ class BrokenController(Presenter):
         boolean: bool = False,
     ) -> None:
         raise RuntimeError("Broken controller")
+
+
+class AsyncMotorController(Presenter):
+    """Presenter whose coroutine slot moves a motor on the shared loop.
+
+    A negative position raises, so that failures inside a dispatched slot
+    can be observed.
+    """
+
+    sig_motor_moved = Signal(str, float)
+
+    def __init__(
+        self,
+        name: str,
+        devices: Mapping[str, Device],
+        /,
+        **_: Any,
+    ) -> None:
+        super().__init__(name, devices)
+        self.moves: list[tuple[str, float]] = []
+        self.loops: list[asyncio.AbstractEventLoop] = []
+        self.shutdown_calls = 0
+
+    def register_providers(self, container: VirtualContainer) -> None:
+        container.register_signals(self)
+
+    def inject_dependencies(self, container: VirtualContainer) -> None:
+        sigs = find_signals(container, ["sig_motor_move"])
+        if "sig_motor_move" in sigs:
+            sigs["sig_motor_move"].connect(self.move)
+
+    async def move(self, motor: str, position: float) -> None:
+        if position < 0:
+            raise ValueError(f"{motor} position out of range: {position}")
+        self.loops.append(asyncio.get_running_loop())
+        await cast("MyMotor", self.devices[motor]).floating.set(position)
+        self.moves.append((motor, position))
+        self.sig_motor_moved.emit(motor, position)
+
+    def shutdown(self) -> None:
+        self.shutdown_calls += 1

--- a/tests/container/mock_pkg/redsun.yaml
+++ b/tests/container/mock_pkg/redsun.yaml
@@ -9,5 +9,7 @@ devices:
 presenters:
   my_controller: mock_pkg.controller:MockController
   broken_controller: mock_pkg.controller:BrokenController
+  async_motor_controller: mock_pkg.controller:AsyncMotorController
 views:
   mock_view: mock_pkg.view:MockQtView
+  motor_view: mock_pkg.view:MockMotorView

--- a/tests/container/mock_pkg/view/__init__.py
+++ b/tests/container/mock_pkg/view/__init__.py
@@ -1,3 +1,3 @@
-from .mock_views import MockQtView
+from .mock_views import MockMotorView, MockQtView
 
-__all__ = ["MockQtView"]
+__all__ = ["MockMotorView", "MockQtView"]

--- a/tests/container/mock_pkg/view/mock_views.py
+++ b/tests/container/mock_pkg/view/mock_views.py
@@ -2,8 +2,12 @@ from __future__ import annotations
 
 from typing import Any
 
+from psygnal import Signal
+from qtpy.QtWidgets import QPushButton
+
 from redsun.view import ViewPosition
 from redsun.view.qt import QtView
+from redsun.virtual import VirtualContainer
 
 
 class MockQtView(QtView):
@@ -15,3 +19,26 @@ class MockQtView(QtView):
     @property
     def view_position(self) -> ViewPosition:
         return ViewPosition.CENTER
+
+
+class MockMotorView(QtView):
+    """Mock Qt view requesting motor moves through the virtual container."""
+
+    sig_motor_move = Signal(str, float)
+
+    def __init__(self, name: str, /, *, motor: str = "my_motor", **kwargs: Any) -> None:
+        super().__init__(name, **kwargs)
+        self.motor = motor
+        self.position = 42.0
+        self.move_button = QPushButton("move", self)
+        self.move_button.clicked.connect(self._on_move_clicked)
+
+    @property
+    def view_position(self) -> ViewPosition:
+        return ViewPosition.CENTER
+
+    def register_providers(self, container: VirtualContainer) -> None:
+        container.register_signals(self)
+
+    def _on_move_clicked(self) -> None:
+        self.sig_motor_move.emit(self.motor, self.position)

--- a/tests/container/test_async_dispatch.py
+++ b/tests/container/test_async_dispatch.py
@@ -1,0 +1,166 @@
+"""End-to-end dispatch of a Qt view signal into a presenter coroutine slot."""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+from mock_pkg.controller import AsyncMotorController
+from mock_pkg.device import MyMotor
+from mock_pkg.view import MockMotorView
+from psygnal import get_async_backend
+
+from redsun.aio import CulsansAsyncioBackend, get_shared_loop, run_coro
+from redsun.containers.container import AppContainer
+from redsun.containers.qt import QtAppContainer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+    from pathlib import Path
+
+    from qtpy.QtWidgets import QApplication
+
+pytestmark = pytest.mark.qt
+
+TIMEOUT = 5.0
+
+
+def wait_until(predicate: Callable[[], bool], timeout: float = TIMEOUT) -> bool:
+    """Poll ``predicate`` from the calling thread until it holds or time runs out."""
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+@pytest.fixture
+def app(
+    qapp: QApplication,
+    mock_entry_points: Any,
+    config_path: Path,
+) -> Iterator[QtAppContainer]:
+    """Boot a Qt container holding a view, a presenter and a mock motor."""
+    container = cast(
+        "QtAppContainer",
+        AppContainer.from_config(str(config_path / "mock_async_config.yaml")),
+    )
+    container.build()
+    container.connect_devices(mock=True)
+    try:
+        yield container
+    finally:
+        if container.is_built:
+            container.shutdown()
+
+
+def _view(app: QtAppContainer) -> MockMotorView:
+    return cast("MockMotorView", app.views["motor_view"])
+
+
+def _presenter(app: QtAppContainer) -> AsyncMotorController:
+    return cast("AsyncMotorController", app.presenters["motor_controller"])
+
+
+def test_container_boots_with_all_components(app: QtAppContainer) -> None:
+    assert app.is_built
+    assert isinstance(app.devices["my_motor"], MyMotor)
+    assert isinstance(_presenter(app), AsyncMotorController)
+    assert isinstance(_view(app), MockMotorView)
+
+
+def test_build_installs_the_async_backend(app: QtAppContainer) -> None:
+    backend = get_async_backend()
+    assert isinstance(backend, CulsansAsyncioBackend)
+    assert backend.running.is_set()
+
+
+def test_view_signal_reaches_the_presenter_coroutine(app: QtAppContainer) -> None:
+    view, presenter = _view(app), _presenter(app)
+
+    view.move_button.click()
+
+    assert wait_until(lambda: len(presenter.moves) == 1)
+    assert presenter.moves == [("my_motor", 42.0)]
+    # the slot ran on the shared loop, not on the Qt thread that emitted
+    assert presenter.loops == [get_shared_loop()]
+
+
+def test_coroutine_slot_drives_the_device(app: QtAppContainer) -> None:
+    view, presenter = _view(app), _presenter(app)
+    motor = cast("MyMotor", app.devices["my_motor"])
+
+    view.position = 3.5
+    view.move_button.click()
+
+    assert wait_until(lambda: len(presenter.moves) == 1)
+    assert run_coro(motor.floating.get_value()) == 3.5
+
+
+def test_presenter_signal_travels_back_to_the_view_thread(
+    app: QtAppContainer,
+) -> None:
+    view, presenter = _view(app), _presenter(app)
+    received: list[tuple[str, float]] = []
+
+    presenter.sig_motor_moved.connect(lambda m, p: received.append((m, p)))
+    view.move_button.click()
+
+    assert wait_until(lambda: len(received) == 1)
+    assert received == [("my_motor", 42.0)]
+
+
+def test_repeated_emissions_are_all_delivered(app: QtAppContainer) -> None:
+    view, presenter = _view(app), _presenter(app)
+
+    for position in (1.0, 2.0, 3.0):
+        view.position = position
+        view.move_button.click()
+
+    assert wait_until(lambda: len(presenter.moves) == 3)
+    assert sorted(p for _, p in presenter.moves) == [1.0, 2.0, 3.0]
+
+
+def test_failing_slot_is_logged_and_does_not_break_dispatch(
+    app: QtAppContainer, caplog: pytest.LogCaptureFixture
+) -> None:
+    view, presenter = _view(app), _presenter(app)
+
+    with caplog.at_level(logging.ERROR, logger="redsun"):
+        view.position = -1.0
+        view.move_button.click()
+        assert wait_until(lambda: "position out of range" in caplog.text)
+
+    assert presenter.moves == []
+
+    view.position = 7.0
+    view.move_button.click()
+    assert wait_until(lambda: presenter.moves == [("my_motor", 7.0)])
+
+
+def test_shutdown_tears_down_presenter_and_backend(app: QtAppContainer) -> None:
+    presenter = _presenter(app)
+    backend = get_async_backend()
+    assert isinstance(backend, CulsansAsyncioBackend)
+
+    app.shutdown()
+
+    assert presenter.shutdown_calls == 1
+    assert not app.is_built
+    assert get_async_backend() is None
+    assert wait_until(lambda: not backend.running.is_set())
+
+
+def test_rebuild_after_shutdown_reinstalls_the_backend(app: QtAppContainer) -> None:
+    first = get_async_backend()
+    app.shutdown()
+
+    app.build()
+    second = get_async_backend()
+
+    assert isinstance(second, CulsansAsyncioBackend)
+    assert second is not first
+    assert second.running.is_set()

--- a/tests/container/test_async_dispatch.py
+++ b/tests/container/test_async_dispatch.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.qt
 
-TIMEOUT = 5.0
+TIMEOUT = 10.0
 
 
 def wait_until(predicate: Callable[[], bool], timeout: float = TIMEOUT) -> bool:

--- a/tests/sdk/test_aio.py
+++ b/tests/sdk/test_aio.py
@@ -1,0 +1,456 @@
+"""Tests for the shared event loop and the culsans-backed psygnal backend."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import logging
+import threading
+import time
+import warnings
+from typing import TYPE_CHECKING, Any
+
+import psygnal._async
+import pytest
+from bluesky.run_engine import _ensure_event_loop_running
+from culsans import QueueShutDown
+from psygnal import Signal, get_async_backend
+from psygnal._async import AsyncioBackend, _AsyncBackend, clear_async_backend
+from psygnal._weak_callback import StrongCoroutineFunction, WeakCoroutineMethod
+
+from redsun import aio
+from redsun.aio import (
+    AwaitableEvent,
+    CulsansAsyncioBackend,
+    _loop_factory,
+    get_shared_loop,
+    run_coro,
+    set_async_backend,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Iterator
+
+    from psygnal._async import QueueItem, SupportedBackend
+
+TIMEOUT = 5.0
+
+
+def wait_until(predicate: Callable[[], bool], timeout: float = TIMEOUT) -> bool:
+    """Poll ``predicate`` from the calling thread until it holds or time runs out."""
+    deadline = time.perf_counter() + timeout
+    while time.perf_counter() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return predicate()
+
+
+class Emitter:
+    sig_motor_move = Signal(str, str, float)
+
+
+class ForeignBackend(_AsyncBackend):
+    """Stand-in for a backend redsun did not install."""
+
+    def __init__(self) -> None:
+        super().__init__("trio")
+        self._running = AwaitableEvent()
+
+    @property
+    def running(self) -> AwaitableEvent:
+        return self._running
+
+    def put(self, item: QueueItem) -> None: ...
+
+    async def run(self) -> None: ...
+
+
+@pytest.fixture(autouse=True)
+def clean_backend() -> Iterator[None]:
+    """Start and end every test with no async backend installed."""
+    clear_async_backend()
+    try:
+        yield
+    finally:
+        clear_async_backend()
+
+
+@pytest.fixture
+def backend() -> CulsansAsyncioBackend:
+    installed = set_async_backend()
+    assert wait_until(installed.running.is_set)
+    return installed
+
+
+def test_set_async_backend_installs_into_psygnal(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    assert get_async_backend() is backend
+    assert backend._backend == "culsans"
+    assert backend.name == "psygnal-culsans"
+    assert backend.running.is_set()
+
+
+def test_set_async_backend_is_idempotent(backend: CulsansAsyncioBackend) -> None:
+    assert set_async_backend() is backend
+
+
+def test_set_async_backend_refuses_a_foreign_backend() -> None:
+    psygnal._async._ASYNC_BACKEND = ForeignBackend()
+    with pytest.raises(RuntimeError, match="already set to: trio"):
+        set_async_backend()
+
+
+@pytest.mark.parametrize("name", ["asyncio", "anyio", "trio"])
+def test_psygnal_cannot_replace_our_backend(
+    backend: CulsansAsyncioBackend, name: SupportedBackend
+) -> None:
+    with pytest.raises(RuntimeError, match="already set to: culsans"):
+        psygnal._async.set_async_backend(name)
+
+
+def test_backend_is_subclass_and_virtual_subclass(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    # real inheritance keeps the ABC contract and mypy happy...
+    assert issubclass(CulsansAsyncioBackend, _AsyncBackend)
+    # ...while the virtual registration is what psygnal's teardown dispatches on
+    assert issubclass(CulsansAsyncioBackend, AsyncioBackend)
+    assert isinstance(get_async_backend(), AsyncioBackend)
+
+
+def test_clear_async_backend_closes_the_queue(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    clear_async_backend()
+
+    assert get_async_backend() is None
+    assert wait_until(lambda: not backend.running.is_set())
+    with pytest.raises(QueueShutDown):
+        backend.put((None, ()))  # type: ignore[arg-type]
+
+
+def test_connecting_a_coroutine_without_a_backend_raises() -> None:
+    async def on_move(motor: str, axis: str, position: float) -> None: ...
+
+    with pytest.raises(RuntimeError, match="No async backend set"):
+        Emitter().sig_motor_move.connect(on_move)
+
+
+def test_connect_coroutine_method_does_not_warn(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    class Presenter:
+        async def move(self, motor: str, axis: str, position: float) -> None: ...
+
+    emitter, presenter = Emitter(), Presenter()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        emitter.sig_motor_move.connect(presenter.move)
+
+    assert [w for w in caught if issubclass(w.category, RuntimeWarning)] == []
+    assert isinstance(emitter.sig_motor_move._slots[-1], WeakCoroutineMethod)
+
+
+def test_connect_coroutine_function(backend: CulsansAsyncioBackend) -> None:
+    async def on_move(motor: str, axis: str, position: float) -> None: ...
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+    assert isinstance(emitter.sig_motor_move._slots[-1], StrongCoroutineFunction)
+
+
+def test_emit_from_foreign_thread_reaches_an_idle_loop(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    delivered = threading.Event()
+    seen: list[tuple[Any, ...]] = []
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        seen.append((motor, axis, position, asyncio.get_running_loop()))
+        delivered.set()
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+
+    # the loop has nothing else to do — this is the case a non-threadsafe
+    # ``put_nowait`` never wakes up
+    emitter.sig_motor_move.emit("stage", "x", 10.0)
+
+    assert delivered.wait(TIMEOUT)
+    motor, axis, position, loop = seen[0]
+    assert (motor, axis, position) == ("stage", "x", 10.0)
+    assert loop is get_shared_loop()
+
+
+def test_slots_run_concurrently_not_serialized(
+    backend: CulsansAsyncioBackend,
+) -> None:
+    done = threading.Event()
+    order: list[str] = []
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        if axis == "slow":
+            await asyncio.sleep(0.3)
+        order.append(axis)
+        if axis == "slow":
+            done.set()
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+
+    start = time.perf_counter()
+    emitter.sig_motor_move.emit("stage", "slow", 1.0)
+    emitter.sig_motor_move.emit("stage", "y", 2.0)
+    emitter.sig_motor_move.emit("stage", "z", 3.0)
+
+    assert done.wait(TIMEOUT)
+    elapsed = time.perf_counter() - start
+
+    assert order == ["y", "z", "slow"]
+    assert elapsed < 0.9, "slow slot serialized the fast ones"
+
+
+def test_raising_slot_is_logged_and_dispatch_survives(
+    backend: CulsansAsyncioBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    delivered = threading.Event()
+    seen: list[float] = []
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        if position < 0:
+            raise ValueError("out of range")
+        seen.append(position)
+        delivered.set()
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+
+    with caplog.at_level(logging.ERROR, logger="redsun"):
+        emitter.sig_motor_move.emit("stage", "x", -1.0)
+        assert wait_until(lambda: "Exception in async slot" in caplog.text)
+
+        emitter.sig_motor_move.emit("stage", "x", 42.0)
+        assert delivered.wait(TIMEOUT)
+
+    record = next(r for r in caplog.records if "async slot" in r.message)
+    assert record.exc_info is not None
+    assert "out of range" in caplog.text
+    assert seen == [42.0]
+    assert backend.running.is_set()
+
+
+def test_cancelled_slot_is_not_logged(
+    backend: CulsansAsyncioBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    started, cancelled = threading.Event(), threading.Event()
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        started.set()
+        try:
+            await asyncio.sleep(TIMEOUT)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+
+    with caplog.at_level(logging.ERROR, logger="redsun"):
+        emitter.sig_motor_move.emit("stage", "x", 1.0)
+        assert started.wait(TIMEOUT)
+        # close() cancels the in-flight slot through the drain's exit path
+        backend.close()
+        assert cancelled.wait(TIMEOUT)
+        assert wait_until(lambda: not backend.running.is_set())
+
+    assert caplog.records == []
+
+
+def test_queue_shutdown_is_not_an_error(
+    backend: CulsansAsyncioBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger="redsun"):
+        backend.close()
+        assert wait_until(lambda: "queue shut down" in caplog.text)
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+
+
+def test_drain_cancellation_is_not_an_error(
+    backend: CulsansAsyncioBackend, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger="redsun"):
+        assert backend._run_task.cancel()
+        assert wait_until(lambda: "Dispatch cancelled" in caplog.text)
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+
+
+def test_unexpected_drain_failure_is_logged(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    calls: list[int] = []
+    real_get_shared_loop = aio.get_shared_loop
+
+    def flaky() -> asyncio.AbstractEventLoop:
+        calls.append(1)
+        # the first call comes from __init__, the second from run()
+        if len(calls) > 1:
+            raise RuntimeError("loop gone")
+        return real_get_shared_loop()
+
+    monkeypatch.setattr(aio, "get_shared_loop", flaky)
+
+    with caplog.at_level(logging.ERROR, logger="redsun"):
+        failing = set_async_backend()
+        assert wait_until(lambda: "Dispatch stopped: loop gone" in caplog.text)
+
+    record = next(r for r in caplog.records if "Dispatch stopped" in r.message)
+    assert record.exc_info is not None
+    assert not failing.running.is_set()
+
+
+def test_dead_weak_callback_is_skipped(backend: CulsansAsyncioBackend) -> None:
+    delivered = threading.Event()
+
+    class Presenter:
+        async def move(self, motor: str, axis: str, position: float) -> None:
+            delivered.set()
+
+    emitter, presenter = Emitter(), Presenter()
+    emitter.sig_motor_move.connect(presenter.move)
+    del presenter
+    gc.collect()
+
+    emitter.sig_motor_move.emit("stage", "x", 1.0)
+    assert not delivered.wait(0.3)
+
+    # the drain is still consuming after dereference() returned None
+    alive = threading.Event()
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        alive.set()
+
+    emitter.sig_motor_move.connect(on_move)
+    emitter.sig_motor_move.emit("stage", "x", 2.0)
+    assert alive.wait(TIMEOUT)
+
+
+@pytest.mark.parametrize("run", [1, 2])
+async def test_delivery_survives_per_test_event_loops(
+    backend: CulsansAsyncioBackend, run: int
+) -> None:
+    """An ``asyncio.Queue`` would bind to the first loop and fail the second."""
+    delivered = threading.Event()
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        delivered.set()
+
+    emitter = Emitter()
+    emitter.sig_motor_move.connect(on_move)
+    emitter.sig_motor_move.emit("stage", "x", float(run))
+
+    assert await asyncio.get_running_loop().run_in_executor(
+        None, delivered.wait, TIMEOUT
+    )
+    assert asyncio.get_running_loop() is not get_shared_loop()
+
+
+def test_close_stops_the_drain(backend: CulsansAsyncioBackend) -> None:
+    backend.close()
+
+    assert wait_until(lambda: not backend.running.is_set())
+    with pytest.raises(QueueShutDown):
+        backend.put((None, ()))  # type: ignore[arg-type]
+
+
+def test_close_is_idempotent(backend: CulsansAsyncioBackend) -> None:
+    backend.close()
+    backend.close()
+    assert wait_until(lambda: not backend.running.is_set())
+
+
+def test_backend_buffers_items_put_before_the_drain_runs() -> None:
+    delivered = threading.Event()
+
+    async def on_move(motor: str, axis: str, position: float) -> None:
+        delivered.set()
+
+    set_async_backend()
+    emitter = Emitter()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        emitter.sig_motor_move.connect(on_move)
+
+    # no wait on `running` — the queue must hold the item until the drain
+    # is scheduled on the shared loop
+    emitter.sig_motor_move.emit("stage", "x", 1.0)
+    assert delivered.wait(TIMEOUT)
+
+
+def test_awaitable_event_set_and_clear() -> None:
+    event = AwaitableEvent()
+    assert not event.is_set()
+    event.set()
+    assert event.is_set()
+    event.clear()
+    assert not event.is_set()
+
+
+async def test_awaitable_event_wait_returns_when_already_set() -> None:
+    event = AwaitableEvent()
+    event.set()
+    await asyncio.wait_for(event.wait(), TIMEOUT)
+
+
+async def test_awaitable_event_wait_wakes_on_a_cross_thread_set() -> None:
+    event = AwaitableEvent()
+    threading.Timer(0.05, event.set).start()
+    await asyncio.wait_for(event.wait(), TIMEOUT)
+    assert event.is_set()
+
+
+def test_shared_loop_is_a_running_singleton() -> None:
+    loop = get_shared_loop()
+    assert get_shared_loop() is loop
+    assert _loop_factory.loop is loop
+    assert loop.is_running()
+    assert _loop_factory._thread is not threading.current_thread()
+
+
+def test_shared_loop_is_known_to_the_bluesky_loop_cache() -> None:
+    loop = get_shared_loop()
+    assert _ensure_event_loop_running.loop_to_thread[loop] is _loop_factory._thread  # type: ignore[attr-defined]
+
+
+def test_run_coro_returns_the_result() -> None:
+    async def answer() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    assert run_coro(answer()) == 42
+
+
+def test_run_coro_runs_on_the_shared_loop() -> None:
+    async def which_loop() -> asyncio.AbstractEventLoop:
+        return asyncio.get_running_loop()
+
+    assert run_coro(which_loop()) is get_shared_loop()
+
+
+def test_run_coro_returns_a_future() -> None:
+    async def answer() -> int:
+        return 42
+
+    future = run_coro(answer(), return_future=True)
+    assert future.result(TIMEOUT) == 42
+
+
+def test_run_coro_propagates_exceptions() -> None:
+    async def boom() -> None:
+        raise ValueError("out of range")
+
+    with pytest.raises(ValueError, match="out of range"):
+        run_coro(boom())

--- a/tests/sdk/test_aio.py
+++ b/tests/sdk/test_aio.py
@@ -78,9 +78,7 @@ def clean_backend() -> Iterator[None]:
 
 @pytest.fixture
 def backend() -> CulsansAsyncioBackend:
-    installed = set_async_backend()
-    assert wait_until(installed.running.is_set)
-    return installed
+    return set_async_backend()
 
 
 def test_set_async_backend_installs_into_psygnal(
@@ -89,7 +87,14 @@ def test_set_async_backend_installs_into_psygnal(
     assert get_async_backend() is backend
     assert backend._backend == "culsans"
     assert backend.name == "psygnal-culsans"
-    assert backend.running.is_set()
+
+
+def test_set_async_backend_returns_a_running_backend() -> None:
+    """The drain starts on another thread, so this must not be observably async."""
+    for _ in range(50):
+        installed = set_async_backend()
+        assert installed.running.is_set()
+        clear_async_backend()
 
 
 def test_set_async_backend_is_idempotent(backend: CulsansAsyncioBackend) -> None:
@@ -358,6 +363,12 @@ async def test_delivery_survives_per_test_event_loops(
     assert asyncio.get_running_loop() is not get_shared_loop()
 
 
+def test_run_does_not_start_a_second_drain(backend: CulsansAsyncioBackend) -> None:
+    """A second ``run()`` must return, not park on the queue alongside the first."""
+    run_coro(asyncio.wait_for(backend.run(), TIMEOUT))
+    assert backend.running.is_set()
+
+
 def test_close_stops_the_drain(backend: CulsansAsyncioBackend) -> None:
     backend.close()
 
@@ -380,9 +391,7 @@ def test_backend_buffers_items_put_before_the_drain_runs() -> None:
 
     set_async_backend()
     emitter = Emitter()
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        emitter.sig_motor_move.connect(on_move)
+    emitter.sig_motor_move.connect(on_move)
 
     # no wait on `running` — the queue must hold the item until the drain
     # is scheduled on the shared loop

--- a/tests/sdk/test_aio.py
+++ b/tests/sdk/test_aio.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 
     from psygnal._async import QueueItem, SupportedBackend
 
-TIMEOUT = 5.0
+TIMEOUT = 10.0
 
 
 def wait_until(predicate: Callable[[], bool], timeout: float = TIMEOUT) -> bool:

--- a/tests/sdk/test_aio.py
+++ b/tests/sdk/test_aio.py
@@ -278,11 +278,8 @@ def test_queue_shutdown_is_not_an_error(
 ) -> None:
     with caplog.at_level(logging.DEBUG, logger="redsun"):
         backend.close()
-        # the drain logs its exit reason before clearing `running`, so waiting
-        # on the flag orders the assertions instead of racing the log
-        assert wait_until(lambda: not backend.running.is_set())
+        assert wait_until(lambda: "queue shut down" in caplog.text)
 
-    assert "queue shut down" in caplog.text
     assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
 
 
@@ -291,9 +288,8 @@ def test_drain_cancellation_is_not_an_error(
 ) -> None:
     with caplog.at_level(logging.DEBUG, logger="redsun"):
         assert backend._run_task.cancel()
-        assert wait_until(lambda: not backend.running.is_set())
+        assert wait_until(lambda: "Dispatch cancelled" in caplog.text)
 
-    assert "Dispatch cancelled" in caplog.text
     assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
 
 
@@ -314,11 +310,11 @@ def test_unexpected_drain_failure_is_logged(
 
     with caplog.at_level(logging.ERROR, logger="redsun"):
         failing = set_async_backend()
-        assert wait_until(lambda: not failing.running.is_set())
+        assert wait_until(lambda: "Dispatch stopped: loop gone" in caplog.text)
 
-    assert "Dispatch stopped: loop gone" in caplog.text
     record = next(r for r in caplog.records if "Dispatch stopped" in r.message)
     assert record.exc_info is not None
+    assert not failing.running.is_set()
 
 
 def test_dead_weak_callback_is_skipped(backend: CulsansAsyncioBackend) -> None:

--- a/tests/sdk/test_aio.py
+++ b/tests/sdk/test_aio.py
@@ -278,8 +278,11 @@ def test_queue_shutdown_is_not_an_error(
 ) -> None:
     with caplog.at_level(logging.DEBUG, logger="redsun"):
         backend.close()
-        assert wait_until(lambda: "queue shut down" in caplog.text)
+        # the drain logs its exit reason before clearing `running`, so waiting
+        # on the flag orders the assertions instead of racing the log
+        assert wait_until(lambda: not backend.running.is_set())
 
+    assert "queue shut down" in caplog.text
     assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
 
 
@@ -288,8 +291,9 @@ def test_drain_cancellation_is_not_an_error(
 ) -> None:
     with caplog.at_level(logging.DEBUG, logger="redsun"):
         assert backend._run_task.cancel()
-        assert wait_until(lambda: "Dispatch cancelled" in caplog.text)
+        assert wait_until(lambda: not backend.running.is_set())
 
+    assert "Dispatch cancelled" in caplog.text
     assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
 
 
@@ -310,11 +314,11 @@ def test_unexpected_drain_failure_is_logged(
 
     with caplog.at_level(logging.ERROR, logger="redsun"):
         failing = set_async_backend()
-        assert wait_until(lambda: "Dispatch stopped: loop gone" in caplog.text)
+        assert wait_until(lambda: not failing.running.is_set())
 
+    assert "Dispatch stopped: loop gone" in caplog.text
     record = next(r for r in caplog.records if "Dispatch stopped" in r.message)
     assert record.exc_info is not None
-    assert not failing.running.is_set()
 
 
 def test_dead_weak_callback_is_skipped(backend: CulsansAsyncioBackend) -> None:

--- a/zensical.toml
+++ b/zensical.toml
@@ -63,6 +63,7 @@ nav = [
     { "Reference" = [
         "reference/index.md",
         { "API" = [
+            { "Async runtime" = "reference/api/aio.md" },
             { "Container" = "reference/api/container.md" },
             { "Device" = "reference/api/device.md" },
             { "Engine" = "reference/api/engine.md" },
@@ -93,6 +94,7 @@ nav = [
             { "2. Storage dual-context redesign" = "explanation/decisions/0002-storage-dual-context-redesign.md" },
             { "3. Structural subtyping for presenters and views" = "explanation/decisions/0003-structural-subtyping-for-presenters-and-views.md" },
             { "4. Owner-scoped signal lookup" = "explanation/decisions/0004-owner-scoped-signal-lookup.md" },
+            { "5. Culsans-backed psygnal async backend" = "explanation/decisions/0005-culsans-psygnal-async-backend.md" },
         ]},
     ]},
 ]


### PR DESCRIPTION
- Adds a custom culsans-backed psygnal backend for dealing with signal dispatching from a synchronous event loop (e.g. Qt) to an asyncio one using a culsans Queue that pops dispatched callbacks into the background loop as a separate background task.
- Heavily Claude-assisted.

A risky point is the fact that, for example, when issuing repeated commands by clicking a button this might cause some contention. It could be solved by not making the task not in background, but at that point the native async backend should be sufficient so this all stuff might go away in the future.

Nevertheless we give it a shot.