### PR TITLE
docs: various fixes and typos

### DIFF
--- a/.claude/agents/container-dev.md
+++ b/.claude/agents/container-dev.md
@@ -7,7 +7,7 @@ model: sonnet
 
 Scope: `src/redsun/virtual/**`, `src/redsun/containers/**`, `tests/container/**`.
 
-Architecture invariants live in CLAUDE.md (Architecture invariants section) —
+Architecture invariants live in CLAUDE.md (Architecture invariants section) -
 read them before editing; don't restate them here.
 
 Extend `tests/container/mock_pkg/` for new plugin fixtures rather than creating

--- a/.claude/agents/docs-updater.md
+++ b/.claude/agents/docs-updater.md
@@ -10,7 +10,7 @@ Scope: `docs/**` and docstrings in `src/redsun/**`.
 Rules:
 - Diataxis placement: tutorials=learning, how-to=task, explanation=rationale,
   reference/api=generated facts.
-- `docs/reference/api/*.md` is mkdocstrings-generated — fix the *docstring* in
+- `docs/reference/api/*.md` is mkdocstrings-generated - fix the *docstring* in
   source, never hand-edit generated reference content.
 - Material admonitions (`!!! note`), mermaid fences for diagrams.
 - numpy docstring convention (ruff pydocstyle).

--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -11,7 +11,7 @@ Check the diff against the invariants in CLAUDE.md (architecture, storage,
 code conventions) and any accepted ADR under `docs/explanation/decisions/`
 that touches the changed area. Additionally:
 
-- public symbol renamed or removed → grep `docs/` for the old name; broken
+- public symbol renamed or removed -> grep `docs/` for the old name; broken
   xrefs do not fail the docs build, so a green build proves nothing.
 
 Output: a bulleted list of concrete issues with file:line. If clean, say so in

--- a/.claude/agents/storage-dev.md
+++ b/.claude/agents/storage-dev.md
@@ -1,13 +1,13 @@
 ---
 name: storage-dev
-description: Work on src/redsun/storage — BaseStorage, backends, FrameRouter. Use for any storage-layer change or bug.
+description: Work on src/redsun/storage - BaseStorage, backends, FrameRouter. Use for any storage-layer change or bug.
 tools: Read, Edit, Bash, Grep, Glob
 model: sonnet
 ---
 
 Scope: `src/redsun/storage/**` and `tests/sdk/storage/**`.
 
-Architecture invariants live in CLAUDE.md (Storage section) — read them before
+Architecture invariants live in CLAUDE.md (Storage section) - read them before
 editing; don't restate them here. The approved redesign is
 `docs/explanation/decisions/0002-storage-dual-context-redesign.md`; while it is
 being implemented, the ADR wins over stale code comments.

--- a/.claude/agents/test-writer.md
+++ b/.claude/agents/test-writer.md
@@ -9,14 +9,14 @@ Mirror the source layout under `tests/sdk/`. Match the style of neighbouring
 test modules and reuse existing fixtures (`RE`, `bus`, `config_path`, `qapp`).
 
 Rules:
-- asyncio_mode is "auto" — never add `@pytest.mark.asyncio`.
+- asyncio_mode is "auto" - never add `@pytest.mark.asyncio`.
 - Qt-dependent tests get `@pytest.mark.qt` and use the `qapp` fixture. Never
   instantiate QApplication directly.
 - One happy-path test drives a full lifecycle through the public interface;
   unhappy paths are small and focused.
 - Parametrize normal + edge cases in a single @pytest.mark.parametrize.
 - Never touch real hardware; use mocks / ophyd-async mock connect.
-- Don't write tests against `src/redsun/view/**` for coverage's sake — it's
+- Don't write tests against `src/redsun/view/**` for coverage's sake - it's
   excluded from coverage.
 
 Iterate `uv run pytest <scope> -x -q` until green.

--- a/.claude/agents/type-checker.md
+++ b/.claude/agents/type-checker.md
@@ -11,9 +11,9 @@ Always run (POSIX shells):
 PowerShell (Windows):
 `uv run mypy src/redsun --ignore-missing-imports @(uv run qtpy mypy-args)`
 
-`cmd.exe` has no command substitution — use PowerShell there.
+`cmd.exe` has no command substitution - use PowerShell there.
 
-This pins the Qt binding and matches CI exactly — a bare `mypy src/redsun` can
+This pins the Qt binding and matches CI exactly - a bare `mypy src/redsun` can
 diverge when multiple Qt bindings are installed, so only the shimmed form is
 authoritative.
 

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -6,7 +6,7 @@ description: Run the full local validation suite
 Run in order, stopping at the first failure:
 
 1. `uv run ruff check --fix . && uv run ruff format .`
-2. mypy with the qtpy shim — pick the form matching the current shell:
+2. mypy with the qtpy shim - pick the form matching the current shell:
    - POSIX: `uv run mypy src/redsun --ignore-missing-imports $(uv run qtpy mypy-args)`
    - PowerShell: `uv run mypy src/redsun --ignore-missing-imports @(uv run qtpy mypy-args)`
    - `cmd.exe` has no command substitution. If that's the shell, run

--- a/.claude/commands/check.md
+++ b/.claude/commands/check.md
@@ -12,6 +12,7 @@ Run in order, stopping at the first failure:
    - `cmd.exe` has no command substitution. If that's the shell, run
      `uv run qtpy mypy-args` first and paste its output into the mypy call.
 3. `uv run pytest -q`
+4. `uv run zensical build && uv run python scripts/check_xrefs.py`
 
 Report a one-line result per step. On failure, show the failing output and fix
 it, then re-run from that step

--- a/.claude/skills/docs-conventions/SKILL.md
+++ b/.claude/skills/docs-conventions/SKILL.md
@@ -12,7 +12,7 @@ description: Conventions for writing and updating docs under docs/ - Diataxis st
 - Reference pages are generated from docstrings: fix the docstring, not the
   `.md`, when reference content is wrong.
 - Architectural decisions are recorded as ADRs under
-  `docs/explanation/decisions/` (numbered, `COPYME` template — same
+  `docs/explanation/decisions/` (numbered, `COPYME` template - same
   convention as ophyd-async). Architecture changes get a new ADR; superseded
   ADRs are marked, not edited. Wire new ADRs into the `zensical.toml` nav and
   `docs/explanation/index.md`.

--- a/.claude/skills/docs-conventions/SKILL.md
+++ b/.claude/skills/docs-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs-conventions
-description: Conventions for writing and updating docs under docs/ — Diataxis structure, ADR recording, and mkdocstrings pitfalls. Use when adding or editing documentation, or when a public API change needs its reference updated.
+description: Conventions for writing and updating docs under docs/ - Diataxis structure, ADR recording, and mkdocstrings pitfalls. Use when adding or editing documentation, or when a public API change needs its reference updated.
 ---
 
 # Docs conventions
@@ -9,15 +9,24 @@ description: Conventions for writing and updating docs under docs/ — Diataxis 
   `explanation/` (rationale), `reference/api/` (mkdocstrings-generated facts).
 - One authoritative source per fact; cross-link instead of restating.
 - Material-style admonitions (`!!! warning`), mermaid fences for diagrams.
-- Reference pages are generated from docstrings — fix the docstring, not the
+- Reference pages are generated from docstrings: fix the docstring, not the
   `.md`, when reference content is wrong.
 - Architectural decisions are recorded as ADRs under
   `docs/explanation/decisions/` (numbered, `COPYME` template — same
   convention as ophyd-async). Architecture changes get a new ADR; superseded
   ADRs are marked, not edited. Wire new ADRs into the `zensical.toml` nav and
   `docs/explanation/index.md`.
-- **A green `zensical build` does not mean the docs are correct.** Broken
-  mkdocstrings xrefs do not fail the build. When changing public API, grep
-  `docs/` for the old symbol name and fix references by hand.
+- **A green `zensical build` does not mean the docs are correct.** An xref that
+  matched nothing is emitted verbatim into the page instead of failing the
+  build. Run the guard after every build:
 
-Build the docs with `uv run zensical build`.
+  ```bash
+  uv run zensical build
+  uv run python scripts/check_xrefs.py
+  ```
+
+  It scans the built `site/` for leftover `][target]` outside code blocks. A
+  hit is either a typo, a symbol that moved, or a third-party object whose
+  inventory is missing from `inventories` in `zensical.toml`. If the project
+  genuinely publishes no such object (event-model's `DocumentRouter`, for
+  one), write it as a plain code span rather than an xref.

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -33,6 +33,9 @@ jobs:
       - name: Build docs
         run: uv run zensical build
 
+      - name: Check cross-references
+        run: uv run python scripts/check_xrefs.py
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         if: success() && github.ref == 'refs/heads/main'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ uv run pytest tests/sdk/storage/test_base_storage.py::test_name
 uv run ruff check --fix . && uv run ruff format .
 uv run mypy --ignore-missing-imports $(uv run qtpy mypy-args)
 uv run zensical build                   # docs
+uv run python scripts/check_xrefs.py    # docs xref guard (after a build)
 ```
 
 - **Windows:** `$(...)` command substitution does not exist in `cmd.exe`. Use

--- a/docs/explanation/architecture/plans.md
+++ b/docs/explanation/architecture/plans.md
@@ -110,11 +110,11 @@ Each parameter becomes a `ParamDescription` with:
 The dispatch is table-driven. Annotations are mapped to `ParamDescription`
 fields in this priority order:
 
-1. `Literal["a", "b"]` → `choices=["a", "b"]`
-2. `Sequence[MyDevice]` → multi-select, `choices=<matching device names>`
-3. `*args: MyDevice` (VAR_POSITIONAL) → multi-select
-4. `MyDevice` (bare protocol) → single-select
-5. Everything else → delegated to magicgui
+1. `Literal["a", "b"]` -> `choices=["a", "b"]`
+2. `Sequence[MyDevice]` -> multi-select, `choices=<matching device names>`
+3. `*args: MyDevice` (VAR_POSITIONAL) -> multi-select
+4. `MyDevice` (bare protocol) -> single-select
+5. Everything else -> delegated to magicgui
 
 Plans with required parameters that fall through to step 5 and are not
 magicgui-resolvable raise `UnresolvableAnnotationError` and are skipped.
@@ -127,7 +127,7 @@ turn widget values into a plan call:
 ```python
 from redsun.presenter.plan_spec import collect_arguments, resolve_arguments
 
-# 1. Resolve: string device names → live device instances
+# 1. Resolve: string device names -> live device instances
 resolved = resolve_arguments(spec, widget_values, devices)
 
 # 2. Collect: build (args, kwargs) matching the plan signature

--- a/docs/explanation/architecture/qt-widgets.md
+++ b/docs/explanation/architecture/qt-widgets.md
@@ -38,10 +38,10 @@ The returned `PlanWidget` is a frozen dataclass that owns the full widget tree:
 The presenter drives UI state through `PlanWidget`'s methods:
 
 ```python
-widget.toggle(True)  # plan started  → "Stop", enables actions
-widget.toggle(False)  # plan stopped  → "Run", disables actions
-widget.pause(True)  # paused        → "Resume", disables run button
-widget.pause(False)  # resumed       → "Pause", enables run button
+widget.toggle(True)  # plan started  -> "Stop", enables actions
+widget.toggle(False)  # plan stopped  -> "Run", disables actions
+widget.pause(True)  # paused        -> "Resume", disables run button
+widget.pause(False)  # resumed       -> "Pause", enables run button
 widget.setEnabled(False)  # disable whole widget during setup
 widget.enable_actions(True)  # enable action buttons independently
 ```

--- a/docs/explanation/container-architecture.md
+++ b/docs/explanation/container-architecture.md
@@ -131,15 +131,15 @@ Examples in the declarative flow:
 
 ```python
 class MyApp(QtAppContainer):
-    motor = declare_device(MyMotor)  # name → "motor"
-    cam = declare_device(MyCamera, alias="detector")  # name → "detector"
+    motor = declare_device(MyMotor)  # name -> "motor"
+    cam = declare_device(MyCamera, alias="detector")  # name -> "detector"
 ```
 
 In the dynamic flow:
 
 ```yaml
 devices:
-  iSCAT channel:           # name → "iSCAT channel"
+  iSCAT channel:           # name -> "iSCAT channel"
     plugin_name: my-plugin
     plugin_id: my_detector
 ```

--- a/docs/explanation/decisions/0001-record-architecture-decisions.md
+++ b/docs/explanation/decisions/0001-record-architecture-decisions.md
@@ -31,4 +31,4 @@ superseded ADRs are marked as such rather than edited.
   implementation.
 - `.claude/agents/` memos and CLAUDE.md summarise and link to ADRs instead of
   being the primary record.
-- ADR pages are wired into the zensical nav under Explanation → Decisions.
+- ADR pages are wired into the zensical nav under Explanation -> Decisions.

--- a/docs/explanation/decisions/0002-storage-dual-context-redesign.md
+++ b/docs/explanation/decisions/0002-storage-dual-context-redesign.md
@@ -14,7 +14,7 @@ layer. Two producer contexts need the same store:
 
 - **Device layer (async):** ophyd-async `StandardDetector` logic
   decomposition (`TriggerLogic` / `AcquireLogic` / `DataLogic`) pushing
-  frames during the prepare → kickoff → complete → collect cycle.
+  frames during the prepare -> kickoff -> complete -> collect cycle.
 - **Callback layer (sync):** `DocumentRouter` presenters running inside the
   RunEngine's `emit_sync` on the loop thread - they can never await.
 
@@ -23,7 +23,7 @@ device: `MedianDevice` in redsun-mimir is a `StandardDetector` whose polling
 `_pump` exists only to reuse the writer. A `write_sig` soft signal further
 patches the gap between "kickoff = start live view" and "now also write".
 
-The `StorageStateMachine` (UNSEALED → SEALING → OPEN → CLOSING, `try_seal`
+The `StorageStateMachine` (UNSEALED -> SEALING -> OPEN -> CLOSING, `try_seal`
 first-writer race, `await_open` parking) exists solely because store-open is
 inferred from the first arriving frame - nothing tells the storage a write
 window started. The `StandardDetector` cycle provides explicit lifecycle
@@ -75,8 +75,8 @@ store opens; they wait in the queue.
 `sink(data_key)` creates the queue and spawns the drain task - legal from
 sync code because every caller (async device prepare, `emit_sync` callback)
 runs on the loop thread. The drain loop is the old `_pusher` inverted:
-`await queue.async_get()` → ensure open → `await store.write(key, frame)` →
-`router.mark_written(key)` → count. `FrameRouter.mark_written` remains the
+`await queue.async_get()` -> ensure open -> `await store.write(key, frame)` ->
+`router.mark_written(key)` -> count. `FrameRouter.mark_written` remains the
 single counter-advance point; ophyd-async `complete()` machinery is untouched
 (it waits on `collections_written_signal` = `signal_for(key)`).
 
@@ -104,10 +104,10 @@ Path allocation stays at first `register` (cheap, no backend I/O), so
 
 ### Close: last drain out closes; flush on clean stop, drop on abort
 
-- Clean (`sink.close()` / `storage.close(flush=True)`): `queue.shutdown()` →
+- Clean (`sink.close()` / `storage.close(flush=True)`): `queue.shutdown()` ->
   drain finishes queued frames, then exits.
 - Abort (`reset_group` / `storage.close(flush=False)`):
-  `queue.shutdown(immediate=True)` → queued frames dropped, fast close.
+  `queue.shutdown(immediate=True)` -> queued frames dropped, fast close.
 
 A burst where no frame ever flowed (live iteration whose action never fired)
 is trivial cleanup: the drain exits without ever having opened, clearing its
@@ -172,24 +172,24 @@ class FrameSink:
 
 ### Lifecycle walkthroughs
 
-**Bounded acquisition (snap):** `TriggerLogic.prepare_internal` →
-`register(spec)`; `DataLogic.prepare_unbounded` → eager `await open()` +
-build provider; kickoff → producer `await put(frame)`; drain writes, counters
-advance; capacity → queue shutdown, drain exits; `complete` observes the
-counter; unstage → last drain out closes with flush.
+**Bounded acquisition (snap):** `TriggerLogic.prepare_internal` ->
+`register(spec)`; `DataLogic.prepare_unbounded` -> eager `await open()` +
+build provider; kickoff -> producer `await put(frame)`; drain writes, counters
+advance; capacity -> queue shutdown, drain exits; `complete` observes the
+counter; unstage -> last drain out closes with flush.
 
 **Live plan (today's shape, transitional):** stage/prepare/kickoff each
 iteration registers keys and allocates a path, opens nothing. Live frames go
-to the buffer signal only. Stream action flips `write_sig` → producer starts
-`put`ting → first written frame lazily opens the store → capacity →
-complete/collect/unstage → drains exit → close. Iterations without an
+to the buffer signal only. Stream action flips `write_sig` -> producer starts
+`put`ting -> first written frame lazily opens the store -> capacity ->
+complete/collect/unstage -> drains exit -> close. Iterations without an
 action create no store.
 
-**Median flow:** descriptor doc → presenter derives `StreamSpec`, registers,
+**Median flow:** descriptor doc -> presenter derives `StreamSpec`, registers,
 obtains its sink (drain parked on an empty queue); Event docs (from
 `trigger_and_read` / `create`+`save` in the scan) carry the frames; presenter
-accumulates per run-uid, computes the median → `put_nowait` → drain lazily
-opens and writes → stop doc → `sink.close()` → drain flushes and exits.
+accumulates per run-uid, computes the median -> `put_nowait` -> drain lazily
+opens and writes -> stop doc -> `sink.close()` -> drain flushes and exits.
 
 ## Consequences
 
@@ -203,8 +203,8 @@ opens and writes → stop doc → `sink.close()` → drain flushes and exits.
   and the lock releases (retryable); `QueueFull` on `put_nowait` is loud,
   never silently dropped.
 - **Testing:** `tests/sdk/storage/test_fsm.py` is replaced by lifecycle tests
-  against the public interface: one happy-path test driving register → sink →
-  put → open → capacity → close asserting backend contents via `MemoryIO`,
+  against the public interface: one happy-path test driving register -> sink ->
+  put -> open -> capacity -> close asserting backend contents via `MemoryIO`,
   plus focused unhappy paths (register-while-open, put-after-capacity,
   abort-drop vs clean-flush, burst-died-without-frames) and a concurrency
   test (several keys putting concurrently - single backend open, all frames
@@ -217,7 +217,7 @@ opens and writes → stop doc → `sink.close()` → drain flushes and exits.
 - **redsun-mimir (staged separately, enabled by this ADR):** `MedianDevice`
   and its logics/signals are deleted - median computation moves to
   `MedianPresenter` consuming Event documents. After the plan rework makes
-  the sink lifecycle the write window (prepare → kickoff → capacity →
+  the sink lifecycle the write window (prepare -> kickoff -> capacity ->
   complete as a plain bounded fly segment), `write_sig` is deleted too. Until
   then, today's plan shapes keep working unchanged against the new storage
   layer.

--- a/scripts/check_xrefs.py
+++ b/scripts/check_xrefs.py
@@ -1,0 +1,43 @@
+"""Fail if the built documentation contains an unresolved cross-reference.
+
+``zensical build`` reports "No issues found" even when a ``[`Name`][target]``
+reference matched nothing: the target is emitted verbatim into the page. This
+script scans the built site for that leftover syntax.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+SITE = Path(__file__).resolve().parent.parent / "site"
+
+# a rendered docstring is printed a second time inside the source block, and a
+# reference written in a code span is documentation about the syntax itself
+LITERAL = re.compile(r"<pre\b.*?</pre>|<code\b.*?</code>", re.DOTALL)
+UNRESOLVED = re.compile(r"\]\[([^\]\s<]*)\]")
+
+
+def main() -> int:
+    """Report every unresolved reference and return the exit status."""
+    if not SITE.is_dir():
+        print(f"{SITE} does not exist; run `uv run zensical build` first")
+        return 1
+
+    found = 0
+    for page in sorted(SITE.rglob("*.html")):
+        prose = LITERAL.sub("", page.read_text(encoding="utf-8"))
+        for match in UNRESOLVED.finditer(prose):
+            print(f"{page.relative_to(SITE).as_posix()}: unresolved [{match.group(1)}]")
+            found += 1
+
+    if found:
+        print(f"\n{found} unresolved cross-reference(s)")
+        return 1
+    print("no unresolved cross-references")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/redsun/common/qt.py
+++ b/src/redsun/common/qt.py
@@ -22,19 +22,16 @@ def ask_file_path(
     title : str
         Dialog title.
     file_filter : str
-        File filter.
-    folder : str, optional
-        Folder to open the dialog in.
-        Default is None.
+        Qt file filter string.
+    folder : str
+        Folder the dialog opens in.
     saving : bool, optional
-        True if the dialog is for saving a file, False otherwise.
-        Default is True.
+        Save dialog if True, open dialog otherwise. Default is True.
 
     Returns
     -------
-    Optional[str]
-        Path to the selected file or None if the user cancels the dialog.
-
+    str | None
+        Selected path, or None if the user cancels the dialog.
     """
     if saving:
         dialog = QtWidgets.QFileDialog.getSaveFileName

--- a/src/redsun/containers/_config.py
+++ b/src/redsun/containers/_config.py
@@ -8,7 +8,7 @@ __all__ = ["AppConfig"]
 class AppConfig(RedSunConfig, total=False):
     """Extended configuration for Redsun application containers.
 
-    Extends [`RedSunConfig`][redsun.virtual.RedSunConfig`] with component sections
+    Extends [`RedSunConfig`][redsun.virtual.RedSunConfig] with component sections
     used by the application layer. These are **not** propagated to components.
     """
 

--- a/src/redsun/engine/actions.py
+++ b/src/redsun/engine/actions.py
@@ -124,10 +124,8 @@ def continous(
 ) -> Callable[[Callable[P, R_co]], ContinousPlan[P, R_co]] | ContinousPlan[P, R_co]:
     """Mark a plan as continuous.
 
-    A *continuous* plan informs the view to provide UI controls that allow
-    the user to start, stop, pause, and resume plan execution.
-
-    Can be used with or without arguments:
+    A continuous plan gets UI controls to start, stop, pause and resume it.
+    Usable with or without arguments:
 
     ```python
     @continous
@@ -154,10 +152,8 @@ def continous(
 
     Notes
     -----
-    The decorator does not modify the function signature. It stores
-    ``togglable`` and ``pausable`` as attributes on the function object
-    (``__togglable__`` and ``__pausable__``), to be retrieved later by
-    `create_plan_spec`.
+    The signature is untouched; the flags are stored on the function as
+    ``__togglable__`` and ``__pausable__``.
     """
 
     def decorator(func: Callable[P, R_co]) -> ContinousPlan[P, R_co]:

--- a/src/redsun/presenter/builtins.py
+++ b/src/redsun/presenter/builtins.py
@@ -33,17 +33,16 @@ class StoragePresenter(Presenter, Loggable):
     """Application-level control point for the session path provider.
 
     Owns the [`SessionPathProvider`][redsun.storage.SessionPathProvider] and
-    exposes it on the virtual container as the ``path_provider`` DI provider,
-    so views and sibling presenters resolve the same instance without
-    constructor threading. Storage instances receive the provider when they
-    are constructed; devices never see it - they only interact with
+    exposes it on the virtual container as the ``path_provider`` provider, so
+    every view and presenter resolves the same instance. Storage instances get
+    it at construction; devices only ever see
     [`BaseStorage`][redsun.storage.BaseStorage].
 
     Wiring:
 
-    - ``sig_pre_launch_notify`` (str) → ``set_plan`` - filenames adopt the plan
+    - ``sig_pre_launch_notify`` (str) -> ``set_plan``: filenames adopt the plan
       name of the upcoming run.
-    - ``sig_plan_done`` → plan resets to ``"unknown"`` so stray bursts are not
+    - ``sig_plan_done`` -> plan resets to ``"unknown"``, so stray bursts are not
       attributed to a finished plan.
 
     Parameters

--- a/src/redsun/presenter/plan_spec.py
+++ b/src/redsun/presenter/plan_spec.py
@@ -561,11 +561,11 @@ def collect_arguments(
 
     Notes
     -----
-    * ``POSITIONAL_ONLY`` and ``POSITIONAL_OR_KEYWORD`` → go into ``args`` in
+    * ``POSITIONAL_ONLY`` and ``POSITIONAL_OR_KEYWORD`` -> ``args``, in
       declaration order.
-    * ``KEYWORD_ONLY`` → go into ``kwargs``.
-    * ``VAR_POSITIONAL`` (``*args``) → sequence is expanded into ``args``.
-    * ``VAR_KEYWORD`` (``**kwargs``) → mapping is merged into ``kwargs``.
+    * ``KEYWORD_ONLY`` -> ``kwargs``.
+    * ``VAR_POSITIONAL`` (``*args``) -> sequence expanded into ``args``.
+    * ``VAR_KEYWORD`` (``**kwargs``) -> mapping merged into ``kwargs``.
     """
     args: list[Any] = []
     kwargs: dict[str, Any] = {}

--- a/src/redsun/storage/_path_provider.py
+++ b/src/redsun/storage/_path_provider.py
@@ -94,35 +94,29 @@ class PlanFilenameProvider(FilenameProvider):
 class SessionPathProvider(PathProvider):
     """Session-scoped path provider.
 
-    Computes path in the canonical layout:
+    Computes paths in the layout:
 
     ```
     base_dir / session_name / YYYY-MM-DD/ <plan>_<counter>{.ext}
     ```
 
-    where the date is evaluated when a path is requested (not when
-    the provider is constructed) and the counter only ever increases,
-    per `(session, plan)`, *across* dates: the date
-    directory groups files, it does not scope the counter.
+    The date is evaluated per request, not at construction. The counter is
+    per `(session, plan)` and only ever increases: the date directory groups
+    files, it does not scope the counter.
 
     Parameters
     ----------
     base_dir : Path | None
-        Base directory for storage. Defaults to `~/redsun-storage`.
-
-        Note: `~` is expanded to the user's home directory.
+        Base directory for storage; `~` is expanded. Defaults to
+        `~/redsun-storage`.
     session : str
-        Session name. Fixed for the provider's lifetime.
-
-        Defaults to `"unknown-session"`.
+        Session name, fixed for the provider's lifetime. Defaults to
+        `"unknown-session"`.
     max_digits : int
-        Zero-padding with for auto-increment counter.
-
-        Defaults to 5 (e.g. `00001`).
+        Zero-padding width for the counter. Defaults to 5 (e.g. `00001`).
     now: Callable[[], datetime] | None
-        Clock used to compute the date directory. For testing.
-
-        Defaults to `datetime.now`.
+        Clock used to compute the date directory, for testing. Defaults to
+        `datetime.now`.
     """
 
     __slots__ = (

--- a/src/redsun/utils/__init__.py
+++ b/src/redsun/utils/__init__.py
@@ -27,15 +27,10 @@ def find_signals(
 ) -> dict[str, SignalInstance]:
     """Find signals in a `VirtualContainer` by name, optionally scoped to an owner.
 
-    The signal registry is keyed by owner first (mirroring
-    ``container.signals[owner][signal]``): different components may expose
-    signals with the same name, and the owner name is what discerns them.
-    Pass *owner* to restrict the lookup to a single component's cache.
-
-    When *owner* is omitted, all registered caches are searched and the
-    first match per name wins - convenient when a signal name is known to
-    be unique, but ambiguous otherwise. Names (or owners) not present in
-    the registry are omitted from the result rather than raising.
+    The registry is keyed by owner first (``container.signals[owner][signal]``),
+    since components may expose signals of the same name. Pass *owner* to scope
+    the lookup to one component; omit it and every cache is searched, first
+    match per name winning. Names not found are omitted rather than raising.
 
     Parameters
     ----------

--- a/src/redsun/view/__init__.py
+++ b/src/redsun/view/__init__.py
@@ -9,24 +9,11 @@ __all__ = ["PView", "View", "ViewPosition"]
 class ViewPosition(str, Enum):
     """Supported view positions.
 
-    Used to define the position of a view component in the main view of the UI.
+    Where a view component sits in the main window.
 
     !!! warning
         These values are based on how Qt manages dock widgets.
         They may change in the future.
-
-    Attributes
-    ----------
-    CENTER : str
-        Center view position.
-    LEFT : str
-        Left view position.
-    RIGHT : str
-        Right view position.
-    TOP : str
-        Top view position.
-    BOTTOM : str
-        Bottom view position.
     """
 
     CENTER = "center"

--- a/src/redsun/virtual/_container.py
+++ b/src/redsun/virtual/_container.py
@@ -212,8 +212,8 @@ class VirtualContainer(dic.DynamicContainer, Loggable):
     ) -> None:
         """Register one or more document callbacks.
 
-        A callback is a [`DocumentRouter`][event_model.DocumentRouter] or any
-        object callable as ``(name, doc)``.
+        A callback is an ``event_model.DocumentRouter`` or any object callable
+        as ``(name, doc)``.
 
         Parameters
         ----------

--- a/tests/sdk/test_plan_widget.py
+++ b/tests/sdk/test_plan_widget.py
@@ -132,7 +132,7 @@ class TestActionButton:
             toggle_states: tuple[str, str] = ("Start", "Stop")
 
         btn = ActionButton(Stream())
-        # unchecked → first state label
+        # unchecked -> first state label
         assert "Start" in btn.text()
         btn.setChecked(True)
         assert "Stop" in btn.text()

--- a/zensical.toml
+++ b/zensical.toml
@@ -110,6 +110,8 @@ inventories = [
     "https://psygnal.readthedocs.io/en/latest/objects.inv",
     "https://docs.python.org/3/objects.inv",
     "https://blueskyproject.io/bluesky/main/objects.inv",
+    "https://blueskyproject.io/ophyd-async/main/objects.inv",
+    "https://python-dependency-injector.ets-labs.org/objects.inv",
 ]
 
 [project.plugins.mkdocstrings.handlers.python.options]


### PR DESCRIPTION
- Add a cross reference check script to ensure that classes linked within the documentation are appropriately rendered.