### PR TITLE
feat: typed provider keys on the virtual container

### DIFF
--- a/docs/explanation/architecture/virtual.md
+++ b/docs/explanation/architecture/virtual.md
@@ -69,6 +69,48 @@ class MyComponent:
 
 [`python-dependency-injector`](https://python-dependency-injector.ets-labs.org/index.html) offers a great deal of options of what kind of resource to shared with other components. Refer to its documentation for more information.
 
+## Typed provider keys
+
+An object shared through the container should be identified by a key rather than
+by an attribute name. A key is a [`ProviderKey`][redsun.virtual.ProviderKey],
+declared in the package that owns the type it identifies:
+
+```python
+import dependency_injector.providers as dip
+
+PATH_PROVIDER = dip.Dependency(instance_of=SessionPathProvider)
+```
+
+The producer binds it, the consumer resolves it:
+
+```python
+class StoragePresenter:
+    def register_providers(self, container: VirtualContainer) -> None:
+        container.provide(PATH_PROVIDER, self._provider)
+
+
+class FileStorageView:
+    def inject_dependencies(self, container: VirtualContainer) -> None:
+        # required: raises KeyError if nothing provided it
+        provider = container.require(PATH_PROVIDER)
+
+        # optional: None when this application has no storage presenter
+        maybe = container.try_require(PATH_PROVIDER)
+```
+
+Both halves are typed: `require(PATH_PROVIDER)` is a `SessionPathProvider` to a
+type checker, and `provide` rejects a wrong value both statically and through
+the key's `instance_of`.
+
+A key names a binding; it does not hold one. Each container keeps its own, so
+two applications in one process never see each other's objects.
+
+!!! note
+
+    Prefer keys for anything new. The dynamic form below still works and is not
+    removed, but it is untyped in both directions and cannot express an optional
+    collaborator.
+
 ## Injected components
 
 Through the `VirtualContainer`, objects provided by other components may be retrieved by implementing the [`IsInjectable`][redsun.virtual.IsInjectable] protocol.

--- a/docs/explanation/decisions/0007-typed-provider-keys.md
+++ b/docs/explanation/decisions/0007-typed-provider-keys.md
@@ -1,0 +1,94 @@
+# 7. Typed provider keys
+
+Date: 2026-07-31
+
+## Status
+
+Accepted
+
+## Context
+
+Objects shared between components go through the virtual container. Until now
+the sharing surface was the container's dynamic attributes:
+
+```python
+container.path_provider = providers.Object(self._provider)  # producer
+provider = container.path_provider()  # consumer
+```
+
+`VirtualContainer` subclasses `DynamicContainer`, so attribute access on it
+returns `Any`. Both halves of that exchange are unchecked. The consumer's
+annotation is a promise, not a check; the attribute name is a string agreed by
+convention; and a consumer whose producer is absent gets `AttributeError`,
+which is indistinguishable from a typo.
+
+`dependency-injector` is properly generic. `providers.Object[T]`,
+`providers.Factory[T]` and `providers.Dependency[T]` all carry their type
+through to the call, so the type information is available and `DynamicContainer`
+is what discards it. The fix is to use the library as intended rather than to
+add an abstraction: a hand-rolled typed key would be `providers.Dependency`
+with a worse name.
+
+Two mechanical facts shaped the result.
+
+`Dependency(instance_of=...)` gives a runtime `isinstance` check alongside the
+static parameter, which is what makes the key self-describing.
+
+`Dependency.override()` mutates the key object itself, and a key is a
+module-level constant, so a binding made through it is process-global. Two
+containers in one process would clobber each other's bindings, which is the
+defect `VirtualContainer.__init__` already avoids by scoping its signal and
+callback registries per instance. Bindings therefore cannot live on the key.
+
+## Decision
+
+A shared object is identified by a **typed key**, a `providers.Dependency[T]`
+exported as `ProviderKey[T]`, and bound per container:
+
+```python
+PATH_PROVIDER = dip.Dependency(instance_of=SessionPathProvider)
+
+container.provide(PATH_PROVIDER, self._provider)  # producer
+provider = container.require(PATH_PROVIDER)  # consumer
+maybe = container.try_require(PATH_PROVIDER)  # optional collaborator
+```
+
+The key is a name, not storage. `VirtualContainer` holds the bindings in its
+own mapping and never calls `Dependency.override`.
+
+`provide` enforces `instance_of` where the value is bound, so a wrong value is
+blamed on the component that supplied it. `require` raises `KeyError` naming the
+key; `try_require` returns `None`, which is how an application states that a
+collaborator is optional rather than expressing it as silence.
+
+A key lives beside the type it identifies, in the package that owns that type,
+and is exported from it. There is no central key module: a plugin defines its
+own keys in its own package, and no plugin has to be listed anywhere for its
+keys to work.
+
+## Consequences
+
+Provider exchange becomes statically checked. `container.require(PATH_PROVIDER)`
+is a `SessionPathProvider` to a type checker, and passing the wrong value to
+`provide` is a type error before it is a runtime one.
+
+Absence becomes expressible. `try_require` returning `None` distinguishes an
+optional collaborator from a typo, where the dynamic attribute made both an
+`AttributeError`.
+
+`container.path_provider` is gone. Any component reading it must move to
+`container.require(PATH_PROVIDER)`, which is a breaking change for out-of-tree
+consumers.
+
+The dynamic-attribute mechanism still exists on `DynamicContainer` and is not
+removed. Nothing forces an existing provider onto keys, but new providers should
+use them, and untyped attribute registration should not be added.
+
+dishka was considered as an alternative and rejected. It resolves dependencies
+by type at a composition root, which inverts this build model: redsun constructs
+plugin instances discovered from configuration at runtime and lets them register
+what they own. Type keys also collide with the plugin model, where two cameras
+or two presenters of one class are normal and the configuration key is the
+identity. The migration would break `register_providers` and
+`inject_dependencies`, which are the public plugin API, in exchange for
+generics that `dependency-injector` already provides.

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -28,3 +28,4 @@ Status, Context, Decision, Consequences.
 - **[4. Owner-scoped signal lookup](decisions/0004-owner-scoped-signal-lookup.md)**
 - **[5. Culsans-backed psygnal async backend](decisions/0005-culsans-psygnal-async-backend.md)**
 - **[6. Application-declared wiring](decisions/0006-application-declared-wiring.md)**
+- **[7. Typed provider keys](decisions/0007-typed-provider-keys.md)**

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -37,6 +37,22 @@ Dates are specified in the format `DD-MM-YYYY`.
   that section. A malformed path, an unbuilt component, or an unknown port
   raises `WiringError` listing what does exist.
 - `Connection` and `WiringError` (`redsun.virtual`).
+- `VirtualContainer.provide()`, `require()` and `try_require()` - share an
+  object under a typed key instead of a dynamic attribute. `require` raises
+  `KeyError` when nothing bound the key; `try_require` returns `None`, which is
+  how an optional collaborator is expressed.
+- `ProviderKey` (`redsun.virtual`) - the type of such a key, a
+  `dependency_injector.providers.Dependency[T]`. `instance_of=` is enforced by
+  `provide`, so a wrong value is blamed where it is supplied.
+- `PATH_PROVIDER` (`redsun.storage`) - the key for the session path provider
+  owned by `StoragePresenter`.
+
+### Changed
+
+- `StoragePresenter` binds its provider with
+  `container.provide(PATH_PROVIDER, ...)`. **Breaking:** the dynamic attribute
+  it used to set is gone; read the provider with
+  `container.require(PATH_PROVIDER)` instead of `container.path_provider()`.
 
   `find_signals` and hand-written `inject_dependencies` are unaffected.
 - `redsun.aio.set_async_backend()` - installs `CulsansAsyncioBackend` as psygnal's

--- a/src/redsun/presenter/builtins.py
+++ b/src/redsun/presenter/builtins.py
@@ -10,11 +10,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from dependency_injector import providers
-
 from redsun.log import Loggable
 from redsun.presenter import Presenter
-from redsun.storage import SessionPathProvider
+from redsun.storage import PATH_PROVIDER, SessionPathProvider
 from redsun.utils import find_signals
 
 if TYPE_CHECKING:
@@ -33,9 +31,9 @@ class StoragePresenter(Presenter, Loggable):
     """Application-level control point for the session path provider.
 
     Owns the [`SessionPathProvider`][redsun.storage.SessionPathProvider] and
-    exposes it on the virtual container as the ``path_provider`` provider, so
-    every view and presenter resolves the same instance. Storage instances get
-    it at construction; devices only ever see
+    binds it to `PATH_PROVIDER` on the virtual container, so every view and
+    presenter resolves the same instance. Storage instances get it at
+    construction; devices only ever see
     [`BaseStorage`][redsun.storage.BaseStorage].
 
     Wiring:
@@ -91,7 +89,7 @@ class StoragePresenter(Presenter, Loggable):
             session=container.session,
             max_digits=self._max_digits,
         )
-        container.path_provider = providers.Object(self._provider)
+        container.provide(PATH_PROVIDER, self._provider)
 
     def inject_dependencies(self, container: VirtualContainer) -> None:
         """Connect plan lifecycle signals to the provider, if present."""

--- a/src/redsun/storage/__init__.py
+++ b/src/redsun/storage/__init__.py
@@ -1,3 +1,5 @@
+import dependency_injector.providers as dip
+
 from ._base import (
     BaseStorage,
     OpenStore,
@@ -10,7 +12,11 @@ from ._path_provider import PathSignals, SessionPathProvider
 from ._registry import clear_registry, get_storage, register_storage, reset_group
 from ._sink import FrameSink
 
+PATH_PROVIDER = dip.Dependency(instance_of=SessionPathProvider)
+"""Key for the session path provider shared by `StoragePresenter`."""
+
 __all__ = [
+    "PATH_PROVIDER",
     "BaseStorage",
     "FrameSink",
     "OpenStore",

--- a/src/redsun/virtual/__init__.py
+++ b/src/redsun/virtual/__init__.py
@@ -1,6 +1,7 @@
 from ._config import RedSunConfig
 from ._container import (
     CallbackType,
+    ProviderKey,
     Signal,
     SignalCache,
     VirtualContainer,
@@ -15,6 +16,7 @@ __all__ = [
     "IsInjectable",
     "IsProvider",
     "Ports",
+    "ProviderKey",
     "RedSunConfig",
     "Signal",
     "SignalCache",

--- a/src/redsun/virtual/_container.py
+++ b/src/redsun/virtual/_container.py
@@ -38,11 +38,15 @@ if TYPE_CHECKING:
 
 K = TypeVar("K")
 V = TypeVar("V")
+T = TypeVar("T")
+
+ProviderKey: TypeAlias = dip.Dependency[T]
+"""A typed key identifying an object shared through the container."""
 
 CallbackType: TypeAlias = Callable[[str, Document], None] | DocumentRouter
 """Type alias for document callback functions."""
 
-__all__ = ["Connection", "Signal", "VirtualContainer"]
+__all__ = ["Connection", "ProviderKey", "Signal", "VirtualContainer"]
 
 SignalCache: TypeAlias = dict[str, SignalInstance]
 """Cache type for storing signal instances registered from component classes."""
@@ -89,6 +93,9 @@ class VirtualContainer(dic.DynamicContainer, Loggable):
         self._names: dict[int, str] = {}
         self._links: list[tuple[SignalInstance, Callable[..., Any]]] = []
         self._connections: list[Connection] = []
+        # bindings are held here rather than through Dependency.override, which
+        # mutates the key itself and would leak between containers in one process
+        self._provided: dict[dip.Dependency[Any], Any] = {}
 
     @property
     def schema_version(self) -> float:
@@ -126,6 +133,73 @@ class VirtualContainer(dic.DynamicContainer, Loggable):
             session=config.get("session", "redsun"),
             metadata=config.get("metadata", {}),
         )
+
+    def provide(self, key: ProviderKey[T], value: T) -> None:
+        """Bind *value* to *key* for this container.
+
+        Parameters
+        ----------
+        key : ProviderKey[T]
+            The key consumers resolve.
+        value : T
+            The object to share. Rebinding an already bound key replaces it.
+
+        Raises
+        ------
+        TypeError
+            If *value* is not an instance of the key's ``instance_of``.
+        """
+        if not isinstance(value, key.instance_of):
+            raise TypeError(
+                f"{value!r} is not an instance of "
+                f"{key.instance_of.__name__}, required by {key!r}"
+            )
+        self._provided[key] = value
+
+    def require(self, key: ProviderKey[T]) -> T:
+        """Resolve *key*, which must be bound.
+
+        Parameters
+        ----------
+        key : ProviderKey[T]
+            The key to resolve.
+
+        Returns
+        -------
+        T
+            The bound value.
+
+        Raises
+        ------
+        KeyError
+            If nothing bound *key*. Providers are bound during
+            ``register_providers``, so a key read before that phase is unbound
+            even when the owning component is present.
+        """
+        try:
+            return cast("T", self._provided[key])
+        except KeyError:
+            raise KeyError(
+                f"nothing provided {key!r}; the component that owns it is "
+                "either absent from this application or has not run "
+                "'register_providers' yet"
+            ) from None
+
+    def try_require(self, key: ProviderKey[T]) -> T | None:
+        """Resolve *key*, or return ``None`` if nothing bound it.
+
+        Parameters
+        ----------
+        key : ProviderKey[T]
+            The key to resolve.
+
+        Returns
+        -------
+        T | None
+            The bound value, or ``None`` for an optional collaborator that this
+            application does not include.
+        """
+        return cast("T | None", self._provided.get(key))
 
     def register_signals(
         self, owner: HasName, name: str | None = None, only: Iterable[str] | None = None

--- a/tests/container/test_container.py
+++ b/tests/container/test_container.py
@@ -32,6 +32,7 @@ from redsun.containers.components import (
 from redsun.presenter import PPresenter
 from redsun.presenter.builtins import StoragePresenter
 from redsun.qt import QtAppContainer
+from redsun.storage import PATH_PROVIDER
 from redsun.view import PView, ViewPosition
 from redsun.virtual import RedSunConfig, WiringError, ports
 
@@ -902,7 +903,7 @@ class TestBuiltinPlugins:
         presenter = container.presenters["storage"]
         assert isinstance(presenter, StoragePresenter)
         # the provider is session-scoped from the config and DI-exposed
-        provider = container.virtual_container.path_provider()
+        provider = container.virtual_container.require(PATH_PROVIDER)
         assert provider is presenter.path_provider
         assert "builtin-session" in provider().directory_path.parts
 

--- a/tests/sdk/test_presenter_builtins.py
+++ b/tests/sdk/test_presenter_builtins.py
@@ -19,6 +19,7 @@ from psygnal import Signal
 
 from redsun.presenter.builtins import StoragePresenter
 from redsun.storage import (
+    PATH_PROVIDER,
     BaseStorage,
     SessionPathProvider,
     StreamSpec,
@@ -72,7 +73,7 @@ def test_register_providers_creates_session_scoped_provider(
     presenter = StoragePresenter("storage", {}, base_dir=str(tmp_path))
     presenter.register_providers(configured_bus)
 
-    provider = configured_bus.path_provider()
+    provider = configured_bus.require(PATH_PROVIDER)
     assert provider is presenter.path_provider
     info = provider()
     date = datetime.now().strftime("%Y-%m-%d")
@@ -114,7 +115,7 @@ async def test_approach_di_container_wires_storage_bursts(
     configured_bus.register_signals(acquisition)
     presenter.inject_dependencies(configured_bus)
 
-    provider = configured_bus.path_provider()
+    provider = configured_bus.require(PATH_PROVIDER)
     io = MemoryIO()
     storage = BaseStorage(io=io, path_provider=provider)
 

--- a/tests/sdk/test_providers.py
+++ b/tests/sdk/test_providers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import dependency_injector.providers as dip
+import pytest
+
+from redsun.virtual import ProviderKey, VirtualContainer
+
+
+class Wanted:
+    def __init__(self, tag: str = "") -> None:
+        self.tag = tag
+
+
+class Unrelated: ...
+
+
+WANTED: ProviderKey[Wanted] = dip.Dependency(instance_of=Wanted)
+OTHER: ProviderKey[Wanted] = dip.Dependency(instance_of=Wanted)
+
+
+def test_provide_and_require_round_trip() -> None:
+    """A bound key resolves to the object that was provided."""
+    container = VirtualContainer()
+    value = Wanted("a")
+
+    container.provide(WANTED, value)
+
+    assert container.require(WANTED) is value
+    assert container.try_require(WANTED) is value
+
+
+@pytest.mark.parametrize("key", [WANTED, OTHER])
+def test_unbound_key_is_absent(key: ProviderKey[Wanted]) -> None:
+    """An unbound key raises from require and is None from try_require."""
+    container = VirtualContainer()
+
+    assert container.try_require(key) is None
+    with pytest.raises(KeyError, match="nothing provided"):
+        container.require(key)
+
+
+def test_wrong_type_is_rejected_at_provide() -> None:
+    """The key's instance_of is enforced where the value is bound."""
+    container = VirtualContainer()
+
+    # mypy already rejects this call: the key carries T, so the mismatch is a
+    # type error before it is a runtime one
+    with pytest.raises(TypeError, match="not an instance of Wanted"):
+        container.provide(WANTED, Unrelated())  # type: ignore[misc]
+
+
+def test_rebinding_replaces_the_value() -> None:
+    """The last value bound to a key wins."""
+    container = VirtualContainer()
+    container.provide(WANTED, Wanted("first"))
+
+    container.provide(WANTED, Wanted("second"))
+
+    assert container.require(WANTED).tag == "second"
+
+
+def test_bindings_do_not_leak_between_containers() -> None:
+    """A key is a name, not storage: each container holds its own binding."""
+    first, second = VirtualContainer(), VirtualContainer()
+
+    first.provide(WANTED, Wanted("first"))
+    second.provide(WANTED, Wanted("second"))
+
+    assert first.require(WANTED).tag == "first"
+    assert second.require(WANTED).tag == "second"
+    assert VirtualContainer().try_require(WANTED) is None

--- a/zensical.toml
+++ b/zensical.toml
@@ -97,6 +97,7 @@ nav = [
             { "4. Owner-scoped signal lookup" = "explanation/decisions/0004-owner-scoped-signal-lookup.md" },
             { "5. Culsans-backed psygnal async backend" = "explanation/decisions/0005-culsans-psygnal-async-backend.md" },
             { "6. Application-declared wiring" = "explanation/decisions/0006-application-declared-wiring.md" },
+            { "7. Typed provider keys" = "explanation/decisions/0007-typed-provider-keys.md" },
         ]},
     ]},
 ]


### PR DESCRIPTION
- Use dependency injector API for a more stable injection mechanism of dependencies