### PR TITLE
test: type safety

### DIFF
--- a/src/redsun/log.py
+++ b/src/redsun/log.py
@@ -10,17 +10,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import MutableMapping
-    from typing import Any
-
-    _LoggerAdapter = logging.LoggerAdapter[logging.Logger]
-else:
-    _LoggerAdapter = logging.LoggerAdapter
+    from typing import Any, ClassVar
 
 
 class GlobalFormatter(logging.Formatter):
     """Custom formatter for log messages."""
 
-    _format = "[%(asctime)s][%(levelname)s]"
+    _format: ClassVar[str] = "[%(asctime)s][%(levelname)s]"
 
     def __init__(self, datefmt: str) -> None:
         super().__init__(datefmt=datefmt)
@@ -46,7 +42,7 @@ class GlobalFormatter(logging.Formatter):
         return formatted
 
 
-class ContextualAdapter(_LoggerAdapter):
+class ContextualAdapter(logging.LoggerAdapter[logging.Logger]):
     """Adapter that adds class and object context to log messages.
 
     It expands the ``kwargs`` to inject the object's class name and name into the log record.
@@ -132,6 +128,6 @@ class Loggable:
     """Mixin class that adds a logger to a class instance with extra contextual information."""
 
     @cached_property
-    def logger(self) -> _LoggerAdapter:
+    def logger(self) -> logging.LoggerAdapter[logging.Logger]:
         """Logger instance with contextual information."""
         return ContextualAdapter(logging.getLogger("redsun"), self)

--- a/tests/container/conftest.py
+++ b/tests/container/conftest.py
@@ -34,7 +34,7 @@ def _make_mock_entry_point() -> mock.Mock:
 
 
 @pytest.fixture
-def mock_entry_points() -> Generator[Any, None, None]:
+def mock_entry_points() -> Generator[None, None, None]:
     """Patch entry_points and importlib.resources to use mock-pkg manifest.
 
     ``container.py`` resolves the manifest via::

--- a/tests/container/helpers.py
+++ b/tests/container/helpers.py
@@ -1,0 +1,38 @@
+"""Shared helpers for container tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, TypeVar
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+C = TypeVar("C")
+
+
+def component(mapping: Mapping[str, object], name: str, kind: type[C], /) -> C:
+    """Fetch a component from a container mapping, checking its class.
+
+    For containers built from a configuration file, where the components are
+    named in the file rather than declared in code and the mapping is typed by
+    the protocol they satisfy.
+
+    Parameters
+    ----------
+    mapping : Mapping[str, object]
+        A container's ``devices``, ``presenters`` or ``views``.
+    name : str
+        Key the component was registered under.
+    kind : type[C]
+        Class the component is expected to be.
+
+    Returns
+    -------
+    C
+        The component, narrowed to *kind*.
+    """
+    found = mapping[name]
+    assert isinstance(found, kind), (
+        f"{name!r} is a {type(found).__name__}, expected {kind.__name__}"
+    )
+    return found

--- a/tests/container/test_async_dispatch.py
+++ b/tests/container/test_async_dispatch.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING
 
 import pytest
+from helpers import component
 from mock_pkg.controller import AsyncMotorController
 from mock_pkg.device import MyMotor
 from mock_pkg.view import MockMotorView
@@ -40,14 +41,12 @@ def wait_until(predicate: Callable[[], bool], timeout: float = TIMEOUT) -> bool:
 @pytest.fixture
 def app(
     qapp: QApplication,
-    mock_entry_points: Any,
+    mock_entry_points: None,
     config_path: Path,
 ) -> Iterator[QtAppContainer]:
     """Boot a Qt container holding a view, a presenter and a mock motor."""
-    container = cast(
-        "QtAppContainer",
-        AppContainer.from_config(str(config_path / "mock_async_config.yaml")),
-    )
+    container = AppContainer.from_config(str(config_path / "mock_async_config.yaml"))
+    assert isinstance(container, QtAppContainer)
     container.build()
     container.connect_devices(mock=True)
     try:
@@ -58,11 +57,11 @@ def app(
 
 
 def _view(app: QtAppContainer) -> MockMotorView:
-    return cast("MockMotorView", app.views["motor_view"])
+    return component(app.views, "motor_view", MockMotorView)
 
 
 def _presenter(app: QtAppContainer) -> AsyncMotorController:
-    return cast("AsyncMotorController", app.presenters["motor_controller"])
+    return component(app.presenters, "motor_controller", AsyncMotorController)
 
 
 def test_container_boots_with_all_components(app: QtAppContainer) -> None:
@@ -91,7 +90,7 @@ def test_view_signal_reaches_the_presenter_coroutine(app: QtAppContainer) -> Non
 
 def test_coroutine_slot_drives_the_device(app: QtAppContainer) -> None:
     view, presenter = _view(app), _presenter(app)
-    motor = cast("MyMotor", app.devices["my_motor"])
+    motor = component(app.devices, "my_motor", MyMotor)
 
     view.position = 3.5
     view.move_button.click()

--- a/tests/container/test_container.py
+++ b/tests/container/test_container.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import yaml
+from helpers import component
 from mock_pkg.controller import (
     AsyncMotorController,
     GroupedController,
@@ -35,6 +36,9 @@ from redsun.qt import QtAppContainer
 from redsun.storage import PATH_PROVIDER
 from redsun.view import PView, ViewPosition
 from redsun.virtual import RedSunConfig, WiringError, ports
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 class TestComponentWrappers:
@@ -259,7 +263,9 @@ class TestAppContainerBuild:
 class TestFromConfig:
     """Tests for YAML-based dynamic container creation."""
 
-    def test_from_config_motor(self, mock_entry_points: Any, config_path: Path) -> None:
+    def test_from_config_motor(
+        self, mock_entry_points: None, config_path: Path
+    ) -> None:
         container = AppContainer.from_config(
             str(config_path / "mock_motor_config.yaml")
         )
@@ -270,7 +276,7 @@ class TestFromConfig:
         assert len(container.devices) == 2
 
     def test_from_config_returns_qt_container(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
 
         container = AppContainer.from_config(
@@ -279,7 +285,7 @@ class TestFromConfig:
         assert isinstance(container, QtAppContainer)
 
     def test_from_config_controller(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         container = AppContainer.from_config(
             str(config_path / "mock_controller_config.yaml")
@@ -288,7 +294,7 @@ class TestFromConfig:
         assert len(container.presenters) == 1
 
     def test_from_config_unknown_frontend_raises(
-        self, mock_entry_points: Any, config_path: Path, tmp_path: Path
+        self, mock_entry_points: None, config_path: Path, tmp_path: Path
     ) -> None:
 
         cfg = {"frontend": "unknown_frontend"}
@@ -1030,106 +1036,107 @@ class TestConstructorSignatureGate:
         assert isinstance(comp.build(), PView)
 
 
+class _WiredApp(AppContainer):
+    """Connects a marked slot; the components are named in code, so typed."""
+
+    motor = declare_device(MyMotor, egu="mm", string="s")
+    mover = declare_presenter(AsyncMotorController)
+    ctrl = declare_presenter(MockController)
+
+    def wire(self) -> None:
+        self.connect(self.mover.sig_motor_moved, self.ctrl.on_motor_moved)
+
+
+class _UnmarkedSlotApp(AppContainer):
+    """Targets a real method that was never marked with ``slot``."""
+
+    mover = declare_presenter(AsyncMotorController)
+    ctrl = declare_presenter(MockController)
+
+    def wire(self) -> None:
+        self.connect(self.mover.sig_motor_moved, self.ctrl.not_connectable)
+
+
+class _MismatchedSlotApp(AppContainer):
+    """Targets a marked slot that takes more arguments than the signal emits."""
+
+    mover = declare_presenter(AsyncMotorController)
+    ctrl = declare_presenter(MockController)
+
+    def wire(self) -> None:
+        self.connect(self.mover.sig_motor_moved, self.ctrl.on_too_many)
+
+
 class TestWiring:
     """Tests for the ``wire`` hook and the connections it records."""
 
-    def _app(self) -> type[AppContainer]:
-        class TestApp(AppContainer):
-            motor = declare_device(MyMotor, egu="mm", string="s")
-            mover = declare_presenter(AsyncMotorController)
-            ctrl = declare_presenter(MockController)
+    @pytest.fixture
+    def app(self) -> Iterator[_WiredApp]:
+        built = _WiredApp().build()
+        yield built
+        if built.is_built:
+            built.shutdown()
 
-            def wire(self) -> None:
-                self.connect(self.mover.sig_motor_moved, self.ctrl.on_motor_moved)
-
-        return TestApp
-
-    def test_declared_connection_is_live_after_build(self) -> None:
+    def test_declared_connection_is_live_after_build(self, app: _WiredApp) -> None:
         """A component attribute resolves to its built instance during wiring."""
-        app = self._app()().build()
+        app.mover.sig_motor_moved.emit("motor", 1.0)
 
-        mover = cast("AsyncMotorController", app.presenters["mover"])
-        ctrl = cast("MockController", app.presenters["ctrl"])
+        assert app.ctrl.moved == [("motor", 1.0)]
 
-        mover.sig_motor_moved.emit("motor", 1.0)
-
-        assert ctrl.moved == [("motor", 1.0)]
-
-    def test_connection_is_recorded_with_both_port_paths(self) -> None:
+    def test_connection_is_recorded_with_both_port_paths(self, app: _WiredApp) -> None:
         """The link names the components by the keys the container knows."""
-        app = self._app()().build()
-
         assert [str(link) for link in app.virtual_container.connections] == [
             "mover.sig_motor_moved -> ctrl.on_motor_moved"
         ]
 
-    def test_shutdown_disconnects(self) -> None:
+    def test_shutdown_disconnects(self, app: _WiredApp) -> None:
         """Teardown drops the links the container made."""
-        app = self._app()().build()
-        mover = cast("AsyncMotorController", app.presenters["mover"])
-        ctrl = cast("MockController", app.presenters["ctrl"])
         app.shutdown()
 
-        mover.sig_motor_moved.emit("motor", 1.0)
+        app.mover.sig_motor_moved.emit("motor", 1.0)
 
-        assert ctrl.moved == []
+        assert app.ctrl.moved == []
         assert app.virtual_container.connections == []
 
     def test_connecting_an_unmarked_method_fails_the_build(self) -> None:
         """Only a marked method is connectable, so a typo cannot pass silently."""
-
-        class TestApp(AppContainer):
-            mover = declare_presenter(AsyncMotorController)
-            ctrl = declare_presenter(MockController)
-
-            def wire(self) -> None:
-                self.connect(self.mover.sig_motor_moved, self.ctrl.not_connectable)
-
         with pytest.raises(WiringError, match="not connectable"):
-            TestApp().build()
+            _UnmarkedSlotApp().build()
 
     def test_incompatible_slot_names_both_ends(self) -> None:
         """A signature mismatch is a build error naming the two ports."""
-
-        class TestApp(AppContainer):
-            mover = declare_presenter(AsyncMotorController)
-            ctrl = declare_presenter(MockController)
-
-            def wire(self) -> None:
-                self.connect(self.mover.sig_motor_moved, self.ctrl.on_too_many)
-
         with pytest.raises(
             WiringError, match="mover.sig_motor_moved -> ctrl.on_too_many"
         ):
-            TestApp().build()
+            _MismatchedSlotApp().build()
 
 
 class TestYamlWiring:
     """Tests for the ``wiring`` section of a configuration file."""
 
-    def _build(self, config_path: Path, mock_entry_points: Any) -> AppContainer:
+    def _build(self, config_path: Path, mock_entry_points: None) -> AppContainer:
         return AppContainer.from_config(
             str(config_path / "mock_wiring_config.yaml")
         ).build()
 
     def test_declared_links_are_live(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         """A rule in the file connects the same ports the Python form would."""
         app = self._build(config_path, mock_entry_points)
-        mover = cast("AsyncMotorController", app.presenters["mover"])
-        ctrl = cast("MockController", app.presenters["ctrl"])
+        mover = component(app.presenters, "mover", AsyncMotorController)
+        ctrl = component(app.presenters, "ctrl", MockController)
 
         mover.sig_motor_moved.emit("motor", 1.0)
 
         assert ctrl.moved == [("motor", 1.0)]
 
     def test_signal_group_members_are_addressed_by_member_name(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         """``component.member`` reaches a signal declared inside a group."""
         app = self._build(config_path, mock_entry_points)
-        grouped = cast("GroupedController", app.presenters["grouped"])
+        grouped = component(app.presenters, "grouped", GroupedController)
 
         grouped.frames.median.emit("a")
         grouped.frames.filtered.emit("b")
@@ -1137,7 +1144,7 @@ class TestYamlWiring:
         assert grouped.seen == ["a", "b"]
 
     def test_the_whole_graph_is_recorded(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         """Every rule appears in the report, named by its port path."""
         app = self._build(config_path, mock_entry_points)
@@ -1149,7 +1156,7 @@ class TestYamlWiring:
         ]
 
     def test_wire_runs_before_the_configuration_section(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         """A container may declare connections in code and in the file."""
         app = AppContainer.from_config(str(config_path / "mock_wiring_config.yaml"))
@@ -1188,7 +1195,7 @@ class TestYamlWiring:
         self,
         rule: dict[str, str],
         expected: str,
-        mock_entry_points: Any,
+        mock_entry_points: None,
         config_path: Path,
         tmp_path: Path,
     ) -> None:
@@ -1202,7 +1209,7 @@ class TestYamlWiring:
             AppContainer.from_config(str(broken)).build()
 
     def test_an_unmarked_method_is_not_a_slot_port(
-        self, mock_entry_points: Any, config_path: Path
+        self, mock_entry_points: None, config_path: Path
     ) -> None:
         """A method exists but is not addressable until it is marked."""
         app = self._build(config_path, mock_entry_points)

--- a/tests/sdk/test_log.py
+++ b/tests/sdk/test_log.py
@@ -1,4 +1,3 @@
-# type: ignore
 from __future__ import annotations
 
 import sys
@@ -45,9 +44,10 @@ def test_loggable(caplog: LogCaptureFixture) -> None:
     assert "Test critical" in caplog.handler.records[4].msg
     assert "Test exception" in caplog.handler.records[5].msg
 
-    for _, record in enumerate(caplog.handler.records):
-        assert "MockLoggable" in record.clsname
-        assert "Test instance" in record.uid
+    for record in caplog.handler.records:
+        # injected through 'extra', so not attributes of LogRecord itself
+        assert "MockLoggable" in getattr(record, "clsname", "")
+        assert "Test instance" in getattr(record, "uid", "")
 
     assert caplog.handler.records[0].levelname == "INFO"
     assert caplog.handler.records[1].levelname == "DEBUG"
@@ -75,5 +75,5 @@ def test_loggable_no_name(caplog: LogCaptureFixture) -> None:
     assert "Test critical" in caplog.handler.records[4].msg
     assert "Test exception" in caplog.handler.records[5].msg
 
-    for _, record in enumerate(caplog.handler.records):
-        assert "LoggableNoName" in record.clsname
+    for record in caplog.handler.records:
+        assert "LoggableNoName" in getattr(record, "clsname", "")


### PR DESCRIPTION
- Enhance type safety of tests, removing some old casts
- Remove a shim for logging.LoggerAdapter which was valid only for python < 3.11