### PR TITLE
feat: resolve annotations of a function through globals

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -16,6 +16,13 @@ Dates are specified in the format `DD-MM-YYYY`.
   would have. `TypeError` is still raised for exactly the same components.
 - A plugin that cannot be loaded into a manifest group now reports what that
   group requires, instead of "does not implement any known protocol".
+- `create_plan_spec` resolves each annotation on its own instead of resolving
+  the whole signature at once. An annotation naming something unavailable at
+  runtime, such as a type imported only under `TYPE_CHECKING`, now raises
+  `UnresolvableAnnotationError` naming the plan and the parameter, where it
+  previously raised `NameError` from `typing`. Such a plan is still rejected:
+  callers that already handle `UnresolvableAnnotationError` can skip it
+  instead of failing the surrounding build.
 
 ## [0.11.0] 01-08-2026
 

--- a/src/redsun/presenter/plan_spec.py
+++ b/src/redsun/presenter/plan_spec.py
@@ -24,14 +24,15 @@ from typing import (
     TYPE_CHECKING,
     Annotated,
     Any,
+    ForwardRef,
     Literal,
     NamedTuple,
     get_args,
     get_origin,
-    get_type_hints,
 )
 
 from ophyd_async.core import Device as OADevice
+from typing_extensions import Format, evaluate_forward_ref, get_annotations
 
 from redsun.engine.actions import Action
 from redsun.presenter.utils import (
@@ -424,6 +425,30 @@ def _is_magicgui_resolvable(ann: Any) -> bool:
         return False
 
 
+def _resolve_annotations(
+    func_obj: cabc.Callable[..., Any],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Resolve every annotation of *func_obj*, one at a time.
+
+    Returns the annotations that evaluate, and the source text of those naming
+    something unavailable at runtime. Resolving them separately keeps a single
+    unimportable name from hiding every other annotation.
+    """
+    namespace = getattr(func_obj, "__globals__", None)
+    resolved: dict[str, Any] = {}
+    unresolved: dict[str, str] = {}
+    for name, text in get_annotations(func_obj, format=Format.STRING).items():
+        try:
+            value = evaluate_forward_ref(ForwardRef(text), globals=namespace)
+        except NameError:
+            unresolved[name] = text
+        else:
+            # get_type_hints substitutes NoneType, which the return-type
+            # checks below rely on to tell "-> None" from "no annotation"
+            resolved[name] = type(None) if value is None else value
+    return resolved, unresolved
+
+
 def create_plan_spec(
     plan: cabc.Callable[..., cabc.Generator[Any, Any, Any]],
     devices: cabc.Mapping[str, OADevice],
@@ -449,6 +474,9 @@ def create_plan_spec(
     TypeError
         If *plan* is not a generator function or its return type is not a
         ``MsgGenerator`` (``Generator[Msg, Any, Any]``).
+    UnresolvableAnnotationError
+        If an annotation names something unavailable at runtime, or cannot be
+        mapped to a widget.
     RuntimeError
         If an unexpected ``inspect.Parameter.kind`` is encountered.
     """
@@ -460,7 +488,13 @@ def create_plan_spec(
         raise TypeError(f"Plan {func_obj.__name__!r} must be a generator function.")
 
     sig = signature(func_obj)
-    type_hints = get_type_hints(func_obj, include_extras=True)
+    type_hints, unresolved = _resolve_annotations(func_obj)
+
+    if "return" in unresolved:
+        raise UnresolvableAnnotationError(
+            func_obj.__name__, "return", unresolved["return"]
+        )
+
     return_type = type_hints.get("return", None)
 
     if return_type is None:
@@ -481,6 +515,9 @@ def create_plan_spec(
     params: list[ParamDescription] = []
 
     for name, param in _iterate_signature(sig):
+        if name in unresolved:
+            raise UnresolvableAnnotationError(func_obj.__name__, name, unresolved[name])
+
         raw_ann: Any = type_hints.get(name, param.annotation)
         if raw_ann is _empty:
             raw_ann = Any

--- a/tests/sdk/test_plan_spec.py
+++ b/tests/sdk/test_plan_spec.py
@@ -7,7 +7,7 @@ from collections.abc import Set as AbstractSet
 from dataclasses import dataclass
 from inspect import Parameter
 from pathlib import Path
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import numpy as np
 import pytest
@@ -37,6 +37,11 @@ from redsun.presenter.plan_spec import (
 from redsun.presenter.utils import isdevice, isdevicesequence, isdeviceset, issequence
 from redsun.view.qt._device_sequence_edit import DeviceSequenceEdit
 from redsun.view.qt._widget_factory import create_param_widget
+
+if TYPE_CHECKING:
+    # deliberately never imported at runtime: a plan annotated with it
+    # reproduces a plugin author hiding an import behind TYPE_CHECKING
+    from decimal import Decimal
 
 
 @runtime_checkable
@@ -409,6 +414,51 @@ class TestUnresolvableAnnotation:
 
         assert "widget" in str(exc_info.value)
         assert "broken" in str(exc_info.value)
+
+
+class TestTypeCheckingOnlyAnnotation:
+    """A name available only to a type checker is reported, not raised as NameError."""
+
+    def test_required_param_raises_unresolvable(self) -> None:
+        def plan(amount: Decimal) -> MsgGenerator[None]:
+            yield from ()
+
+        with pytest.raises(UnresolvableAnnotationError) as exc_info:
+            create_plan_spec(plan, {})
+
+        err = exc_info.value
+        assert err.plan_name == "plan"
+        assert err.param_name == "amount"
+        assert err.annotation == "Decimal"
+
+    def test_unresolvable_return_raises_unresolvable(self) -> None:
+        def plan(count: int) -> Decimal:  # type: ignore[misc]
+            yield from ()
+
+        with pytest.raises(UnresolvableAnnotationError) as exc_info:
+            create_plan_spec(plan, {})  # type: ignore[arg-type]
+
+        assert exc_info.value.param_name == "return"
+
+    def test_resolvable_siblings_do_not_mask_the_bad_one(self) -> None:
+        """The failure names the offending parameter, not the first one."""
+
+        def plan(count: int, path: Path, amount: Decimal) -> MsgGenerator[None]:
+            yield from ()
+
+        with pytest.raises(UnresolvableAnnotationError) as exc_info:
+            create_plan_spec(plan, {})
+
+        assert exc_info.value.param_name == "amount"
+
+    def test_optional_unresolvable_param_still_raises(self) -> None:
+        """Strict by design: a default does not make an unreadable name acceptable."""
+
+        def plan(amount: Decimal | None = None) -> MsgGenerator[None]:
+            yield from ()
+
+        with pytest.raises(UnresolvableAnnotationError):
+            create_plan_spec(plan, {})
 
 
 class TestDispatchAnnotation:


### PR DESCRIPTION
- evaluate forward references using globals as namespace
- this does not protect against TYPE_CHECKING imports (not sure if they'll ever work...)

Performance wise this should *not* impact too much, the cost of checking globals seems minimal...