### PR TITLE
refactor: inherit and reuse as much as possible from QBaseValueWidget

### DIFF
--- a/src/redsun/view/qt/_device_sequence_edit.py
+++ b/src/redsun/view/qt/_device_sequence_edit.py
@@ -18,8 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from magicgui.backends._qtpy.widgets import EventFilter
-from magicgui.widgets import protocols
+from magicgui.backends._qtpy.widgets import QBaseValueWidget
 from magicgui.widgets.bases import ValueWidget
 from psygnal import Signal
 from qtpy import QtCore
@@ -29,114 +28,50 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-class _QCheckboxBackend(protocols.ValueWidgetProtocol):
+class _QCheckboxBackend(QBaseValueWidget):
     """Qt backend for ``DeviceSequenceEdit``.
 
     Wraps ``_CheckboxListWidget`` and satisfies ``ValueWidgetProtocol`` so
     magicgui's container machinery accepts it as a first-class widget.
     """
 
+    _qwidget: _CheckboxListWidget
+
     def __init__(self, parent: QtW.QWidget | None = None, **kwargs: Any) -> None:
         choices: list[str] = kwargs.pop("choices", [])
-        self._qwidget = _CheckboxListWidget(choices=choices)
-        if parent is not None:
-            self._qwidget.setParent(parent)
-        self._event_filter = EventFilter()
-        self._qwidget.installEventFilter(self._event_filter)
-        self._change_callback: Callable[[Any], Any] | None = None
-        self._qwidget.selection_changed.connect(self._on_change)
+        super().__init__(
+            _CheckboxListWidget,
+            "get_value",
+            "set_value",
+            "selection_changed",
+            parent=parent,
+            **kwargs,
+        )
+        self._qwidget.set_choices(choices)
 
-    def _mgui_get_value(self) -> list[str]:
-        return self._qwidget.get_value()
+    def _mgui_bind_change_callback(self, callback: Callable[[Any], Any]) -> None:
+        """Connect unconditionally.
+
+        The inherited version tests the signal for truthiness first, which
+        holds for a Qt signal but not for a psygnal one: with no connections
+        yet it is falsy, and the callback would be dropped.
+        """
+        self._qwidget.selection_changed.connect(callback)
 
     def _mgui_set_value(self, value: Any) -> None:
+        """Accept any iterable of names, and treat ``None`` as an empty selection."""
         if isinstance(value, (list, tuple, set, frozenset)):
             self._qwidget.set_value(list(value))
         elif value is None:
             self._qwidget.set_value([])
 
-    def _mgui_bind_change_callback(self, callback: Callable[[Any], Any]) -> None:
-        self._change_callback = callback
-
-    def _on_change(self, value: list[str]) -> None:
-        if self._change_callback is not None:
-            self._change_callback(value)
-
-    def _mgui_close_widget(self) -> None:
-        self._qwidget.close()
-
-    def _mgui_get_visible(self) -> bool:
-        return self._qwidget.isVisible()
-
-    def _mgui_set_visible(self, value: bool) -> None:
-        self._qwidget.setVisible(value)
-
-    def _mgui_get_enabled(self) -> bool:
-        return self._qwidget.isEnabled()
-
-    def _mgui_set_enabled(self, enabled: bool) -> None:
-        self._qwidget.setEnabled(enabled)
-
-    def _mgui_get_parent(self) -> Any:
-        return self._qwidget.parent()
-
-    def _mgui_set_parent(self, widget: Any) -> None:
-        native = widget.native if hasattr(widget, "native") else widget
-        self._qwidget.setParent(native)
-
-    def _mgui_get_native_widget(self) -> QtW.QWidget:
-        return self._qwidget
-
-    def _mgui_get_root_native_widget(self) -> QtW.QWidget:
-        return self._qwidget
-
     def _mgui_get_width(self) -> int:
+        """Report the preferred width: the list grows with the device pool."""
         return self._qwidget.sizeHint().width()
 
-    def _mgui_set_width(self, value: int) -> None:
-        self._qwidget.resize(int(value), self._qwidget.height())
-
-    def _mgui_get_min_width(self) -> int:
-        return self._qwidget.minimumWidth()
-
-    def _mgui_set_min_width(self, value: int) -> None:
-        self._qwidget.setMinimumWidth(int(value))
-
-    def _mgui_get_max_width(self) -> int:
-        return self._qwidget.maximumWidth()
-
-    def _mgui_set_max_width(self, value: int) -> None:
-        self._qwidget.setMaximumWidth(int(value))
-
     def _mgui_get_height(self) -> int:
+        """Report the preferred height: the list grows with the device pool."""
         return self._qwidget.sizeHint().height()
-
-    def _mgui_set_height(self, value: int) -> None:
-        self._qwidget.resize(self._qwidget.width(), int(value))
-
-    def _mgui_get_min_height(self) -> int:
-        return self._qwidget.minimumHeight()
-
-    def _mgui_set_min_height(self, value: int) -> None:
-        self._qwidget.setMinimumHeight(int(value))
-
-    def _mgui_get_max_height(self) -> int:
-        return self._qwidget.maximumHeight()
-
-    def _mgui_set_max_height(self, value: int) -> None:
-        self._qwidget.setMaximumHeight(int(value))
-
-    def _mgui_get_tooltip(self) -> str:
-        return self._qwidget.toolTip()
-
-    def _mgui_set_tooltip(self, value: str | None) -> None:
-        self._qwidget.setToolTip(str(value) if value else "")
-
-    def _mgui_bind_parent_change_callback(self, callback: Callable[..., Any]) -> None:
-        self._event_filter.parentChanged.connect(callback)
-
-    def _mgui_render(self) -> Any:  # pragma: no cover
-        raise NotImplementedError
 
 
 class DeviceSequenceEdit(ValueWidget[list[str]]):
@@ -185,37 +120,44 @@ class DeviceSequenceEdit(ValueWidget[list[str]]):
 class _CheckboxListWidget(QtW.QWidget):
     """Vertical stack of ``QCheckBox`` widgets plus a count label.
 
-    Parameters
-    ----------
-    choices : list[str]
-        Ordered list of device names.
+    Choices are supplied after construction through ``set_choices``, since
+    magicgui's backend base instantiates the Qt widget itself.
     """
 
     selection_changed = Signal(list)
 
-    def __init__(
-        self,
-        choices: list[str],
-        parent: QtW.QWidget | None = None,
-    ) -> None:
+    def __init__(self, parent: QtW.QWidget | None = None) -> None:
         super().__init__(parent)
         self._checkboxes: dict[str, QtW.QCheckBox] = {}
 
-        layout = QtW.QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(2)
-
-        for name in choices:
-            cb = QtW.QCheckBox(name)
-            cb.toggled.connect(self._emit)
-            layout.addWidget(cb)
-            self._checkboxes[name] = cb
+        self._layout = QtW.QVBoxLayout(self)
+        self._layout.setContentsMargins(0, 0, 0, 0)
+        self._layout.setSpacing(2)
 
         self._count_label = QtW.QLabel()
         self._count_label.setAlignment(QtCore.Qt.AlignmentFlag.AlignRight)
         self._count_label.setStyleSheet("color: #888; font-size: 10px;")
-        layout.addWidget(self._count_label)
+        self._layout.addWidget(self._count_label)
 
+        self._update_count_label()
+
+    def set_choices(self, choices: list[str]) -> None:
+        """Replace the device pool, above the count label.
+
+        An outgoing checkbox is disconnected before it is dropped: left
+        connected it would keep emitting selections that ``get_value`` no
+        longer reports.
+        """
+        for stale in self._checkboxes.values():
+            stale.toggled.disconnect(self._emit)
+            stale.setParent(None)
+            stale.deleteLater()
+        self._checkboxes.clear()
+        for name in choices:
+            cb = QtW.QCheckBox(name)
+            cb.toggled.connect(self._emit)
+            self._layout.insertWidget(self._layout.count() - 1, cb)
+            self._checkboxes[name] = cb
         self._update_count_label()
 
     def get_value(self) -> list[str]:


### PR DESCRIPTION
- only override what's actually needed
- add a set_choices method to set the device names in the widget