### PR TITLE
feat: add container hooks and build phase registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,20 @@ uv run python scripts/check_xrefs.py    # docs xref guard (after a build)
   symbols need docstrings; `D100`/`D104` are ignored.
 - Private modules are `_underscored`; the package `__init__.py` re-exports the
   public surface with explicit `__all__`. Add new public symbols to both.
+- **The underscore marks what `__all__` cannot.** A module named `_foo.py` is
+  private in its entirety, so its **module-level members carry no underscore** -
+  the module name already said it, and repeating it at every call site is noise.
+  What is public is what the package `__init__.py` lists in `__all__`.
+  **Class members always keep the underscore**, in a private module too:
+  `__all__` is module-scoped and can never say that a method is private, and the
+  docs filter (`filters = ["!^_", "!^__"]` in `zensical.toml`) and a reader's
+  autocomplete both key on the name. So `_hooks.py` holds `parse_hook_specs`,
+  but `AppContainer._build_devices` stays underscored.
+  Two consequences: ruff `D103` treats a non-underscore function as public, so
+  helpers in a private module need docstrings; and a reference page targeting a
+  *module* rather than an object needs an explicit `members:` list, because
+  mkdocstrings selects `__all__` **union** non-underscore members, never
+  `__all__` alone.
 - Public methods are named in the imperative: `wire`, `build`, `connect`,
   `release`, not `wiring`, `building` or `connection`. A method does something;
   the name says what it does, not what it is. Nouns are for the things a method

--- a/docs/explanation/decisions/0008-container-hooks-and-the-phase-registry.md
+++ b/docs/explanation/decisions/0008-container-hooks-and-the-phase-registry.md
@@ -1,0 +1,102 @@
+# 8. Container hooks and the build phase registry
+
+Date: 2026-08-26
+
+## Status
+
+Accepted
+
+## Context
+
+A session may need to adjust the application container itself, rather than any
+one component. The case that forced the question is theming: a bundle that
+embeds a third-party widget brings that widget's own stylesheet, and confining
+it to one widget makes the window look like two applications stitched together.
+Applying it to the whole application has to happen before any view is built,
+which is inside `build`, where no component has a say.
+
+`build` was a straight-line body, so there was no way to add a step to it and
+no name for any point inside it. The only extension points were `wire`, which
+runs at one fixed place, and overriding `build` in a subclass, which does not
+compose: two packages that both want to adjust the build cannot both be the
+subclass.
+
+Whatever mechanism was chosen had to work from a configuration file as well as
+from Python, because a session assembled entirely from YAML is a first-class
+way to run redsun and must not lose a capability that a container class has.
+
+## Decision
+
+**The build sequence is a registry, not a straight-line body.** `AppContainer`
+holds `_phases`, an insertion-ordered mapping of name to bound method, built in
+`__init__`. `build` iterates it. The shape is `RunEngine._command_registry` from
+bluesky, already a dependency: a dict of bound methods populated in `__init__`
+and read publicly through a property.
+
+Bound methods rather than a module-level table of names, for two reasons.
+Unbound references would call the base implementation even on a subclass that
+overrides a phase, losing the override; binding through the instance keeps it.
+And a string-keyed `getattr` is invisible to a type checker, so a mistyped
+phase name would need a runtime test to catch, where a bound method is reported
+directly.
+
+**Insertion is public, permutation is not.** `register_phase(name, phase,
+after=...)` adds a step; `unregister_phase` removes one; `phases` reports the
+order. The RunEngine's registry is order-free, because a plan's message stream
+decides sequence and registering a command changes no order. Here the order is
+the semantic content, so:
+
+- `after` is required. There is no meaningful default position.
+- The built-in phases cannot be removed or reordered. Four orderings are
+  load-bearing - the bus before everything, devices before presenters, every
+  component before wiring, every provider registration before any injection -
+  and they stay guarantees rather than hopes.
+- Registration is only legal before `build`, mirroring the storage layer's rule
+  that `register` is legal only before `open`.
+
+**Hook providers are plain objects, checked structurally.** A provider
+implements `ConfiguresBuild` to adjust the sequence, `HasShutdown` to undo what
+it did, or both; each is checked independently with `isinstance`, which is the
+idiom `build` already uses for `IsProvider` and `IsInjectable`. There is no base
+class to inherit and no protocol that demands methods a provider does not want,
+so a class defining one method is a complete provider.
+
+**A session names providers in either of two places, and both feed one list.** A
+configuration file names them by dotted path, since YAML cannot hold a class; a
+container class lists instances, since an author writing Python already holds
+the provider. The two concatenate, class-level first. Neither overrides the
+other: silent override would decide behaviour by which of two files the reader
+is not looking at.
+
+**Teardown is symmetric and owned by the container.** `shutdown` walks the
+providers in reverse, after the presenters, logging failures rather than
+raising - the opposite of the setup rule, because a failing teardown happens
+while the application is already going down and must not block the rest. The
+container additionally restores the phase sequence it captured before the hooks
+ran, so a container built twice does not accumulate phases and a hook author
+does not have to hold a container reference to undo a registration.
+
+**Failures during setup raise.** A device that fails to build is logged and
+skipped, because missing hardware must not abort a session. A hook that does
+not resolve is a typo in a configuration file, not a missing instrument. A
+provider satisfying none of the protocols its container calls raises for the
+same reason: it would silently do nothing.
+
+## Consequences
+
+- A bundle can ship application-wide behaviour as one class and a session opts
+  in with one configuration entry, without subclassing the container.
+- Two packages can each contribute to the same session, which a subclass-based
+  extension point cannot express.
+- `build` has a vocabulary: every step has a name a hook can address, and the
+  names appear in the debug log.
+- A phase registered by hand survives a rebuild; a phase registered by a hook
+  does not. That asymmetry is deliberate - the container undoes what it caused.
+- `hooks` is declared as a `Sequence` and normalised to a tuple, so a class body
+  can use a tuple and avoid the mutable-class-attribute lint that a list form
+  would trip in every downstream package.
+- The protocols a container calls are a class attribute, so a container for
+  another toolkit extends the set rather than redefining the check.
+- Nothing is configurable that would break the four load-bearing orderings: the
+  sequence is data so that hooks can address it, not so that a session file can
+  rewrite it.

--- a/docs/reference/api/container.md
+++ b/docs/reference/api/container.md
@@ -17,6 +17,14 @@
     options:
       show_root_heading: true
 
+::: redsun.containers.ConfiguresBuild
+    options:
+      show_root_heading: true
+
+::: redsun.containers.HookError
+    options:
+      show_root_heading: true
+
 ::: redsun.qt.QtAppContainer
     options:
       show_root_heading: true

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Dates are specified in the format `DD-MM-YYYY`.
 
+## [Unreleased]
+
+### Added
+
+- The build sequence is a registry a caller can add to.
+  `AppContainer.phases` reports the phases in the order `build` runs them, and
+  `register_phase(name, phase, after=...)` inserts a step after a named one.
+  `after` is required, since where a phase runs is what it means;
+  `unregister_phase` removes a registered phase but refuses the built-in ones,
+  whose order the container guarantees. Both are legal only before `build`.
+
+  ```python
+  app = MyApp()
+  app.register_phase("calibrate", calibrate, after="injection")
+  app.build()
+  ```
+
+- **Container hooks** - an object a session installs on its application
+  container to adjust the application as a whole, rather than any one
+  component. A provider implements `ConfiguresBuild` to adjust the build
+  sequence, `HasShutdown` to undo what it did, or both; each is checked on its
+  own, so a class defining one method is a complete provider.
+
+  Providers are named in a configuration file by dotted path, with the
+  remaining keys forwarded to the constructor:
+
+  ```yaml
+  hooks:
+    - provider: "mypkg.hooks:Calibration"
+      passes: 3
+  ```
+
+  or listed as instances on a container class, which is what an author writing
+  Python already holds:
+
+  ```python
+  class MyApp(QtAppContainer):
+      hooks = (Calibration(passes=3),)
+  ```
+
+  The two sources concatenate, class-level first, and neither overrides the
+  other. A subclass inherits what its bases declare. `HookError` is raised for
+  an entry that does not resolve, or a provider that satisfies none of the hook
+  protocols its container calls.
+
+  Hooks are torn down in reverse order with the container, after the
+  presenters; a failing teardown is logged and does not block the rest. The
+  container also restores the phase sequence it captured before the hooks ran,
+  so building a container twice does not accumulate phases.
+
+  See [Container hooks and the build phase
+  registry](../explanation/decisions/0008-container-hooks-and-the-phase-registry.md).
+
 ## [0.11.1]
 
 ### Changed

--- a/src/redsun/containers/__init__.py
+++ b/src/redsun/containers/__init__.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from ._config import AppConfig
+from ._hooks import ConfiguresBuild, HookError
 from .components import declare_device, declare_presenter, declare_view
 from .container import AppContainer, Frontend
 
 __all__ = [
     "AppConfig",
     "AppContainer",
+    "ConfiguresBuild",
     "Frontend",
+    "HookError",
     "declare_device",
     "declare_presenter",
     "declare_view",

--- a/src/redsun/containers/_config.py
+++ b/src/redsun/containers/_config.py
@@ -16,3 +16,4 @@ class AppConfig(RedSunConfig, total=False):
     presenters: NotRequired[dict[str, Any]]
     views: NotRequired[dict[str, Any]]
     wiring: NotRequired[list[dict[str, str]]]
+    hooks: NotRequired[list[dict[str, Any]]]

--- a/src/redsun/containers/_hooks.py
+++ b/src/redsun/containers/_hooks.py
@@ -1,0 +1,115 @@
+"""Hook providers a session installs on its application container."""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from collections.abc import Mapping
+from dataclasses import dataclass
+from importlib import import_module
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+    from redsun.containers.container import AppContainer
+
+__all__ = ["ConfiguresBuild", "HookError"]
+
+logger = logging.getLogger("redsun")
+
+
+class HookError(RuntimeError):
+    """A ``hooks`` configuration entry cannot be turned into a provider."""
+
+
+@runtime_checkable
+class ConfiguresBuild(Protocol):
+    """Adjusts the build sequence before any phase of it runs."""
+
+    @abstractmethod
+    def configure_build(self, container: AppContainer) -> None:
+        """Register or remove build phases on *container*."""
+        ...
+
+
+@dataclass(frozen=True, slots=True)
+class HookSpec:
+    """One entry of the configuration ``hooks`` section."""
+
+    provider: str
+    kwargs: Mapping[str, Any]
+
+
+def parse_hook_specs(raw: Sequence[Mapping[str, Any]]) -> list[HookSpec]:
+    """Read the ``hooks`` section into one spec per entry.
+
+    Raises
+    ------
+    HookError
+        If an entry is not a mapping, or carries no string ``provider`` key.
+    """
+    specs: list[HookSpec] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, Mapping):
+            raise HookError(
+                f"hooks entry {index} must be a mapping, got {type(entry).__name__}"
+            )
+        provider = entry.get("provider")
+        if not isinstance(provider, str):
+            raise HookError(
+                f"hooks entry {index} must carry a string 'provider' naming a "
+                f"class as 'module:ClassName', got {provider!r}"
+            )
+        specs.append(
+            HookSpec(
+                provider=provider,
+                kwargs={k: v for k, v in entry.items() if k != "provider"},
+            )
+        )
+    return specs
+
+
+def resolve_hooks(specs: Iterable[HookSpec]) -> list[object]:
+    """Instantiate the provider each spec names, passing its remaining keys.
+
+    Raises
+    ------
+    HookError
+        If a provider path is malformed, names a module or attribute that does
+        not exist, or names something that cannot be instantiated with the
+        keys given.
+    """
+    return [instantiate(spec) for spec in specs]
+
+
+def instantiate(spec: HookSpec) -> object:
+    """Import the class *spec* names and construct it with the spec's keys.
+
+    Raises
+    ------
+    HookError
+        If the path is malformed, does not import, does not name a class, or
+        names one that rejects the keys given.
+    """
+    module_name, _, class_name = spec.provider.partition(":")
+    if not module_name or not class_name:
+        raise HookError(
+            f"hook provider {spec.provider!r} is not a class path; "
+            "expected 'module:ClassName'"
+        )
+    try:
+        imported = getattr(import_module(module_name), class_name)
+    except (ImportError, AttributeError) as e:
+        raise HookError(f"cannot import hook provider {spec.provider!r}: {e}") from e
+    if not isinstance(imported, type):
+        raise HookError(
+            f"hook provider {spec.provider!r} names {imported!r}, which is not a class"
+        )
+    try:
+        return imported(**spec.kwargs)
+    except TypeError as e:
+        raise HookError(
+            f"cannot construct hook provider {spec.provider!r} with "
+            f"{sorted(spec.kwargs)}: {e}"
+        ) from e

--- a/src/redsun/containers/container.py
+++ b/src/redsun/containers/container.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
+
+# resolved at runtime: the ClassVar annotation below is evaluated by ruff's
+# runtime-evaluated rules and by anything calling get_type_hints on a subclass
+from collections.abc import Sequence  # noqa: TC003
 from enum import Enum, unique
 from importlib import import_module
 from importlib.metadata import EntryPoints, entry_points
@@ -30,6 +34,12 @@ from ophyd_async.core import Device
 
 from redsun.aio import _loop_factory, run_coro
 from redsun.containers._config import AppConfig
+from redsun.containers._hooks import (
+    ConfiguresBuild,
+    HookError,
+    parse_hook_specs,
+    resolve_hooks,
+)
 from redsun.containers.components import (
     _ComponentField,
     _DeviceComponent,
@@ -154,6 +164,19 @@ _PLUGIN_EXPECTATIONS: dict[PLUGIN_GROUPS, str] = {
     "views": "must accept exactly ('name',) as its leading positional parameter",
 }
 
+_BUILTIN_PHASES: frozenset[str] = frozenset(
+    {
+        "virtual_container",
+        "devices",
+        "presenters",
+        "views",
+        "providers",
+        "wiring",
+        "injection",
+    }
+)
+"""The phases every container runs, which no caller may remove or reorder."""
+
 _FRONTEND_CONTAINERS: dict[str, str] = {
     "pyqt": "redsun.containers.qt._container.QtAppContainer",
     "pyside": "redsun.containers.qt._container.QtAppContainer",
@@ -199,8 +222,10 @@ class AppContainer:
         "_components",
         "_config",
         "_devices_connected",
+        "_hooks",
         "_is_built",
         "_phases",
+        "_phases_before_hooks",
         "_virtual_container",
     )
 
@@ -208,6 +233,21 @@ class AppContainer:
     _presenter_components: ClassVar[dict[str, _PresenterComponent]] = {}
     _view_components: ClassVar[dict[str, _ViewComponent]] = {}
     _config_path: ClassVar[Path | None] = None
+
+    hooks: ClassVar[Sequence[object]] = ()
+    """Hook providers this container installs, ahead of the configured ones.
+
+    Instances, not class paths: a container class is written in Python, where
+    the provider is already in hand. A subclass inherits what its bases
+    declare, ahead of its own.
+    """
+
+    _hook_protocols: ClassVar[tuple[type, ...]] = (ConfiguresBuild, HasShutdown)
+    """The hook protocols this container calls.
+
+    A provider satisfying none of them is refused, since it would silently do
+    nothing. A subclass adding hook points extends this.
+    """
 
     def __init_subclass__(
         cls,
@@ -309,6 +349,12 @@ class AppContainer:
         cls._presenter_components = presenters
         cls._view_components = views
 
+        inherited: list[object] = []
+        for base in cls.__bases__:
+            if issubclass(base, AppContainer):
+                inherited.extend(base.hooks)
+        cls.hooks = (*inherited, *namespace.get("hooks", ()))
+
         if devices or presenters or views:
             logger.debug(
                 f"Collected from {cls.__name__}: "
@@ -324,6 +370,7 @@ class AppContainer:
             "frontend": frontend,
         }
         self._virtual_container: VirtualContainer | None = None
+        self._hooks: tuple[object, ...] = ()
         self._is_built: bool = False
         self._built_devices: dict[str, Device] = {}
         self._devices_connected: bool = False
@@ -340,6 +387,7 @@ class AppContainer:
             "wiring": self._apply_wiring,
             "injection": self._inject_dependencies,
         }
+        self._phases_before_hooks: dict[str, BuildPhase] = {}
 
         # In the declarative subclass path (class MyApp(QtAppContainer, config=...))
         # the metaclass loads the YAML only to resolve component kwargs and never
@@ -443,7 +491,9 @@ class AppContainer:
     def build(self) -> Self:
         """Instantiate all components in dependency order.
 
-        The registered phases run in order:
+        Hook providers are resolved first and given the chance to adjust the
+        sequence, which is why registering a phase is only legal until here.
+        The registered phases then run in order:
 
         1. VirtualContainer
         2. Devices
@@ -463,6 +513,14 @@ class AppContainer:
 
         logger.info("Building application container...")
 
+        self._hooks = self._resolve_hook_providers()
+        # what a hook adds to the sequence is undone when it is torn down, so
+        # that a container built a second time does not accumulate phases
+        self._phases_before_hooks = dict(self._phases)
+        for hook in self._hooks:
+            if isinstance(hook, ConfiguresBuild):
+                hook.configure_build(self)
+
         for name, phase in self._phases.items():
             phase()
             logger.debug(f"Build phase '{name}' complete")
@@ -476,6 +534,103 @@ class AppContainer:
         )
 
         return self
+
+    @property
+    def phases(self) -> list[str]:
+        """The build phases, in the order `build` runs them."""
+        return list(self._phases)
+
+    def register_phase(self, name: str, phase: BuildPhase, *, after: str) -> None:
+        """Add *phase* to the build sequence, directly after the phase *after*.
+
+        There is no default position: where a phase runs is what it means, so
+        *after* names an existing phase and is required.
+
+        Raises
+        ------
+        RuntimeError
+            If the container is already built.
+        ValueError
+            If *name* is already registered, or *after* is not a known phase.
+        """
+        self._refuse_after_build("register a phase")
+        if name in self._phases:
+            raise ValueError(f"build phase {name!r} is already registered")
+        if after not in self._phases:
+            raise ValueError(
+                f"cannot place phase {name!r} after unknown phase {after!r}. "
+                f"Known phases: {', '.join(self._phases)}"
+            )
+        rebuilt: dict[str, BuildPhase] = {}
+        for existing, existing_phase in self._phases.items():
+            rebuilt[existing] = existing_phase
+            if existing == after:
+                rebuilt[name] = phase
+        self._phases = rebuilt
+
+    def unregister_phase(self, name: str) -> None:
+        """Remove a previously registered phase.
+
+        Raises
+        ------
+        RuntimeError
+            If the container is already built.
+        ValueError
+            If *name* is not registered, or names one of the built-in phases:
+            the order they run in is what the container guarantees.
+        """
+        self._refuse_after_build("unregister a phase")
+        if name in _BUILTIN_PHASES:
+            raise ValueError(
+                f"build phase {name!r} is built in and cannot be removed. "
+                f"Built-in phases: {', '.join(_BUILTIN_PHASES)}"
+            )
+        if name not in self._phases:
+            raise ValueError(f"build phase {name!r} is not registered")
+        del self._phases[name]
+
+    def _refuse_after_build(self, action: str) -> None:
+        if self._is_built:
+            raise RuntimeError(f"cannot {action} after the container is built")
+
+    def _resolve_hook_providers(self) -> tuple[object, ...]:
+        """Instantiate the class-level hook providers, then the configured ones.
+
+        Raises
+        ------
+        HookError
+            If an entry does not resolve, or a provider satisfies none of the
+            hook protocols this container calls.
+        """
+        resolved: list[object] = [
+            *type(self).hooks,
+            *resolve_hooks(parse_hook_specs(self._config.get("hooks", []))),
+        ]
+        for hook in resolved:
+            if not isinstance(hook, self._hook_protocols):
+                known = ", ".join(p.__name__ for p in self._hook_protocols)
+                raise HookError(
+                    f"hook provider {type(hook).__name__!r} implements none of "
+                    f"the hook protocols {type(self).__name__} calls, so it "
+                    f"would do nothing. It must implement one of: {known}."
+                )
+        return tuple(resolved)
+
+    def _shutdown_hooks(self) -> None:
+        """Undo what the hook providers did, in reverse order of installation."""
+        for hook in reversed(self._hooks):
+            if isinstance(hook, HasShutdown):
+                try:
+                    hook.shutdown()
+                except Exception as e:  # noqa: BLE001 - one failure must not block the rest
+                    logger.error(
+                        f"Error shutting down hook '{type(hook).__name__}': {e}"
+                    )
+        # a container always holds the built-in phases, so an empty snapshot
+        # means `build` never took one and there is nothing to restore
+        if self._phases_before_hooks:
+            self._phases = self._phases_before_hooks
+        self._hooks = ()
 
     def _create_virtual_container(self) -> None:
         """Create the VirtualContainer and hand it the session configuration."""
@@ -570,7 +725,7 @@ class AppContainer:
         self._devices_connected = True
 
     def shutdown(self) -> None:
-        """Shutdown all presenters that implement ``HasShutdown``."""
+        """Shutdown all presenters and hooks that implement ``HasShutdown``."""
         if not self._is_built:
             return
 
@@ -583,6 +738,9 @@ class AppContainer:
                     comp.instance.shutdown()
                 except Exception as e:  # noqa: BLE001 - one failed shutdown must not block the rest
                     logger.error(f"Error shutting down presenter '{name}': {e}")
+
+        # after the components, which may still be using what a hook installed
+        self._shutdown_hooks()
 
         self._is_built = False
         logger.info("Container shutdown complete")
@@ -630,6 +788,8 @@ class AppContainer:
         )
         if "wiring" in config:
             instance._config["wiring"] = config["wiring"]
+        if "hooks" in config:
+            instance._config["hooks"] = config["hooks"]
 
         return instance
 

--- a/src/redsun/virtual/_protocols.py
+++ b/src/redsun/virtual/_protocols.py
@@ -15,7 +15,7 @@ class HasShutdown(Protocol):  # pragma: no cover
     def shutdown(self) -> None:
         """Shutdown an object. Perform cleanup operations.
 
-        For use in presenters.
+        For use in presenters and in container hooks.
         """
         ...
 

--- a/tests/container/mock_pkg/hooks.py
+++ b/tests/container/mock_pkg/hooks.py
@@ -1,0 +1,49 @@
+"""Hook providers used by the container hook tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from redsun.containers import AppContainer
+
+installed: list[str] = []
+"""Every phase a `RecordingHook` added and has not torn down, in install order.
+
+Module level rather than per instance so that a test can assert on what a
+container built from a configuration file installed, without holding the
+provider the container resolved.
+"""
+
+
+class RecordingHook:
+    """Adds one build phase and removes it again on shutdown."""
+
+    def __init__(self, name: str = "recorded", after: str = "injection") -> None:
+        self.name = name
+        self.after = after
+        self.ran: list[str] = []
+
+    def configure_build(self, container: AppContainer) -> None:
+        container.register_phase(self.name, self._run, after=self.after)
+        installed.append(self.name)
+
+    def shutdown(self) -> None:
+        installed.remove(self.name)
+
+    def _run(self) -> None:
+        self.ran.append(self.name)
+
+
+class NoopHook:
+    """Implements no hook protocol at all."""
+
+
+class FailingShutdownHook:
+    """Tears down by raising."""
+
+    def configure_build(self, container: AppContainer) -> None:
+        pass
+
+    def shutdown(self) -> None:
+        raise RuntimeError("teardown blew up")

--- a/tests/container/test_hooks.py
+++ b/tests/container/test_hooks.py
@@ -1,0 +1,281 @@
+"""Tests for container-level hook providers and the build phase registry."""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+from mock_pkg import hooks as mock_hooks
+
+from redsun.containers import AppContainer, HookError
+
+_PROVIDER = "mock_pkg.hooks:RecordingHook"
+
+
+@pytest.fixture(autouse=True)
+def _clear_installed() -> None:
+    mock_hooks.installed.clear()
+
+
+class TestPhaseRegistry:
+    """Tests for the public build phase API."""
+
+    def test_a_registered_phase_runs_where_it_was_placed(self) -> None:
+        calls: list[str] = []
+        app = AppContainer()
+        app.register_phase("mine", lambda: calls.append("mine"), after="devices")
+
+        assert app.phases.index("mine") == app.phases.index("devices") + 1
+
+        app.build()
+
+        assert calls == ["mine"]
+
+    def test_phases_reports_the_built_in_sequence(self) -> None:
+        assert AppContainer().phases == [
+            "virtual_container",
+            "devices",
+            "presenters",
+            "views",
+            "providers",
+            "wiring",
+            "injection",
+        ]
+
+    def test_a_registered_phase_can_be_removed_again(self) -> None:
+        app = AppContainer()
+        app.register_phase("mine", lambda: None, after="views")
+        app.unregister_phase("mine")
+
+        assert app.phases == AppContainer().phases
+
+    @pytest.mark.parametrize("name", ["devices", "wiring", "virtual_container"])
+    def test_a_built_in_phase_cannot_be_removed(self, name: str) -> None:
+        with pytest.raises(ValueError, match="built in and cannot be removed"):
+            AppContainer().unregister_phase(name)
+
+    def test_registering_after_an_unknown_phase_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="unknown phase 'nope'"):
+            AppContainer().register_phase("mine", lambda: None, after="nope")
+
+    def test_registering_a_known_name_twice_is_refused(self) -> None:
+        app = AppContainer()
+        with pytest.raises(ValueError, match="already registered"):
+            app.register_phase("devices", lambda: None, after="views")
+
+    def test_removing_an_unregistered_phase_is_refused(self) -> None:
+        with pytest.raises(ValueError, match="is not registered"):
+            AppContainer().unregister_phase("mine")
+
+    @pytest.mark.parametrize("action", ["register", "unregister"])
+    def test_the_sequence_is_frozen_once_built(self, action: str) -> None:
+        app = AppContainer().build()
+
+        with pytest.raises(RuntimeError, match="after the container is built"):
+            if action == "register":
+                app.register_phase("mine", lambda: None, after="devices")
+            else:
+                app.unregister_phase("mine")
+
+    def test_a_registered_phase_belongs_to_one_container(self) -> None:
+        app = AppContainer()
+        app.register_phase("mine", lambda: None, after="devices")
+
+        assert "mine" not in AppContainer().phases
+
+
+class TestHookResolution:
+    """Tests for turning the 'hooks' configuration section into providers."""
+
+    def test_a_class_level_hook_configures_the_build(self) -> None:
+        hook = mock_hooks.RecordingHook()
+
+        class TestApp(AppContainer):
+            hooks = (hook,)
+
+        TestApp().build()
+
+        assert hook.ran == ["recorded"]
+
+    def test_a_configured_hook_configures_the_build(self) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [{"provider": _PROVIDER}]
+
+        app.build()
+
+        assert "recorded" in app.phases
+
+    def test_extra_keys_reach_the_provider_constructor(self) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [
+            {"provider": _PROVIDER, "name": "custom", "after": "views"}
+        ]
+
+        app.build()
+
+        assert app.phases.index("custom") == app.phases.index("views") + 1
+
+    def test_a_subclass_keeps_the_hooks_its_base_declares(self) -> None:
+        base_hook = mock_hooks.RecordingHook(name="base")
+        own_hook = mock_hooks.RecordingHook(name="own")
+
+        class Base(AppContainer):
+            hooks = (base_hook,)
+
+        class Derived(Base):
+            hooks = (own_hook,)
+
+        # a list, because mypy reads the annotation off the class body and
+        # cannot see the tuple __init_subclass__ puts there instead
+        assert list(Derived.hooks) == [base_hook, own_hook]
+
+    def test_class_level_hooks_run_before_configured_ones(self) -> None:
+        class TestApp(AppContainer):
+            hooks = (mock_hooks.RecordingHook(name="from_class"),)
+
+        app = TestApp()
+        app._config["hooks"] = [{"provider": _PROVIDER, "name": "from_config"}]
+
+        app.build()
+
+        assert mock_hooks.installed == ["from_class", "from_config"]
+
+    def test_no_hooks_section_changes_nothing(self) -> None:
+        assert AppContainer().build().phases == AppContainer().phases
+
+    def test_a_provider_implementing_no_hook_protocol_is_refused(self) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [{"provider": "mock_pkg.hooks:NoopHook"}]
+
+        with pytest.raises(HookError, match="implements none of the hook protocols"):
+            app.build()
+
+    @pytest.mark.parametrize(
+        ("provider", "expected"),
+        [
+            ("mock_pkg.hooks", "not a class path"),
+            ("mock_pkg.nope:Hook", "cannot import"),
+            ("mock_pkg.hooks:Missing", "cannot import"),
+            ("mock_pkg.hooks:installed", "is not a class"),
+        ],
+    )
+    def test_an_unresolvable_provider_names_what_is_wrong(
+        self, provider: str, expected: str
+    ) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [{"provider": provider}]
+
+        with pytest.raises(HookError, match=expected):
+            app.build()
+
+    def test_an_unexpected_key_names_the_provider(self) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [{"provider": _PROVIDER, "nope": 1}]
+
+        with pytest.raises(HookError, match="cannot construct hook provider"):
+            app.build()
+
+    @pytest.mark.parametrize("entry", [{"name": "x"}, {"provider": 1}, "a string"])
+    def test_an_entry_without_a_provider_names_its_index(self, entry: object) -> None:
+        app = AppContainer()
+        app._config["hooks"] = [entry]  # type: ignore[list-item]
+
+        with pytest.raises(HookError, match="hooks entry 0"):
+            app.build()
+
+
+class TestHookTeardown:
+    """Tests for undoing what a hook installed."""
+
+    def test_a_hook_is_torn_down_with_the_container(self) -> None:
+        hook = mock_hooks.RecordingHook()
+
+        class TestApp(AppContainer):
+            hooks = (hook,)
+
+        app = TestApp().build()
+        assert mock_hooks.installed == ["recorded"]
+
+        app.shutdown()
+
+        assert mock_hooks.installed == []
+
+    def test_rebuilding_leaves_one_of_what_the_hook_installed(self) -> None:
+        class TestApp(AppContainer):
+            hooks = (mock_hooks.RecordingHook(),)
+
+        app = TestApp()
+        app.build()
+        app.shutdown()
+        app.build()
+
+        assert mock_hooks.installed == ["recorded"]
+        assert app.phases.count("recorded") == 1
+
+    def test_a_phase_registered_by_hand_survives_a_rebuild(self) -> None:
+        app = AppContainer()
+        app.register_phase("mine", lambda: None, after="devices")
+
+        app.build()
+        app.shutdown()
+
+        assert "mine" in app.phases
+
+    def test_hooks_are_torn_down_in_reverse_order(self) -> None:
+        order: list[str] = []
+
+        class Recorder:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+            def configure_build(self, container: AppContainer) -> None:
+                pass
+
+            def shutdown(self) -> None:
+                order.append(self.name)
+
+        class TestApp(AppContainer):
+            hooks = (
+                Recorder("first"),
+                Recorder("second"),
+            )
+
+        TestApp().build().shutdown()
+
+        assert order == ["second", "first"]
+
+    def test_a_failing_teardown_does_not_block_the_next(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        hook = mock_hooks.RecordingHook()
+
+        class TestApp(AppContainer):
+            hooks = (
+                hook,
+                mock_hooks.FailingShutdownHook(),
+            )
+
+        app = TestApp().build()
+        with caplog.at_level(logging.ERROR, logger="redsun"):
+            app.shutdown()
+
+        assert "teardown blew up" in caplog.text
+        assert mock_hooks.installed == []
+
+    def test_a_hook_without_a_teardown_is_skipped(self) -> None:
+        class NoTeardown:
+            def configure_build(self, container: AppContainer) -> None:
+                pass
+
+        class TestApp(AppContainer):
+            hooks = (NoTeardown(),)
+
+        TestApp().build().shutdown()
+
+    def test_a_shutdown_without_a_build_leaves_the_sequence_alone(self) -> None:
+        app = AppContainer()
+        app._is_built = True
+
+        app.shutdown()
+
+        assert app.phases == AppContainer().phases

--- a/zensical.toml
+++ b/zensical.toml
@@ -98,6 +98,7 @@ nav = [
             { "5. Culsans-backed psygnal async backend" = "explanation/decisions/0005-culsans-psygnal-async-backend.md" },
             { "6. Application-declared wiring" = "explanation/decisions/0006-application-declared-wiring.md" },
             { "7. Typed provider keys" = "explanation/decisions/0007-typed-provider-keys.md" },
+            { "8. Container hooks and the build phase registry" = "explanation/decisions/0008-container-hooks-and-the-phase-registry.md" },
         ]},
     ]},
 ]


### PR DESCRIPTION
- perform each hook at specific lifetime moments of the build cycle
- components may use hooks to customize build operations (i.e. using napari default settings to globally set the theme)