### PR TITLE
feat: add session configuration hook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,6 +125,12 @@ uv run python scripts/check_xrefs.py    # docs xref guard (after a build)
 - psygnal signal attributes are `sig_snake_case` (the `sig_` prefix is
   optional), never `sigCamelCase`. Same-named signals across components are
   discerned by owner: `find_signals(container, names, owner=...)` (ADR 0004).
+- **A `__slots__` class that owns a psygnal `Signal` needs `__weakref__` among
+  its slots.** psygnal refers to a signal's owner weakly, and silently falls
+  back to a strong reference when it cannot; a slotted class cannot be referred
+  to weakly without that slot, and on the fallback the owner is never collected
+  - taking everything it holds with it. A class with a `__dict__` never reaches
+  that path, so this only bites where `__slots__` is declared.
 - asyncio only, no threads for I/O. Hardware goes through `ophyd-async`.
 - Public API change -> docstring + `docs/reference/changelog.md` entry. The root
   `CHANGELOG.md` is only a redirect to it; never add entries there.

--- a/docs/explanation/decisions/0008-container-hooks-and-the-phase-registry.md
+++ b/docs/explanation/decisions/0008-container-hooks-and-the-phase-registry.md
@@ -68,6 +68,30 @@ the provider. The two concatenate, class-level first. Neither overrides the
 other: silent override would decide behaviour by which of two files the reader
 is not looking at.
 
+**A hook that only watches gets a signal, not a hook point.** A splash screen
+naming the step in progress does not want to add work at a moment; it wants to
+observe the sequence. Through the registry that is one registered phase per
+label, each doing nothing but emit a string. `sig_phase_complete` carries the
+name of each phase as it finishes, and a provider connects to it in
+`configure_build` - so the opt-in is still configuration, not code. It lives on
+`AppContainer` rather than on `VirtualContainer` because the bus is created
+*by* the first phase and so could not report that phase.
+
+This forces `__weakref__` into `AppContainer.__slots__`. psygnal keeps one
+`SignalInstance` per owner and refers to that owner weakly, both in the
+instance itself and in the `weakref.finalize` that drops its cache entry. Both
+fall back to a strong reference when the owner cannot be weakly referenced, and
+a class using `__slots__` cannot be unless `__weakref__` is among its slots.
+The fallback is deliberate on psygnal's part - it keeps signals working for
+owners that are neither hashable nor weak-referenceable - but its cost here is
+that no container is ever collected: not the container, nor its devices,
+presenters, views, bus or connections. An ordinary class never reaches this
+path, because psygnal stores the `SignalInstance` as a plain attribute when the
+owner has a `__dict__`; only a slotted owner does.
+
+The rule generalises past this signal: **a `__slots__` class that owns a
+psygnal `Signal` needs `__weakref__` in its slots.**
+
 **Teardown is symmetric and owned by the container.** `shutdown` walks the
 providers in reverse, after the presenters, logging failures rather than
 raising - the opposite of the setup rule, because a failing teardown happens

--- a/docs/reference/api/container.md
+++ b/docs/reference/api/container.md
@@ -21,6 +21,10 @@
     options:
       show_root_heading: true
 
+::: redsun.containers.ConfiguresSession
+    options:
+      show_root_heading: true
+
 ::: redsun.containers.HookError
     options:
       show_root_heading: true

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -24,6 +24,33 @@ Dates are specified in the format `DD-MM-YYYY`.
   app.build()
   ```
 
+- `ConfiguresSession`, a hook point that runs once every component is built,
+  wired and injected. It is the closing half of the pair `ConfiguresBuild`
+  opens: previously the only way to reach that point was
+  `register_phase(..., after="injection")`, which names an implementation
+  detail to get somewhere the lifecycle already describes. It fires after
+  `is_built` is set, so a hook can read `devices`, `presenters` and `views`.
+
+- `AppContainer.sig_phase_complete`, emitted with the name of each build phase
+  as it finishes. For watching the build rather than taking part in it: a
+  splash screen naming the step in progress connects to this in
+  `configure_build`, where adding a phase per step would mean registering
+  seven phases to display seven labels.
+
+  ```python
+  class Splash:
+      def configure_build(self, container: AppContainer) -> None:
+          container.sig_phase_complete.connect(self._show)
+
+      def _show(self, phase: str) -> None: ...
+  ```
+
+  `AppContainer.__slots__` gains `__weakref__` to carry this signal. psygnal
+  refers to a signal's owner weakly and falls back to a strong reference when
+  it cannot; a class using `__slots__` cannot be referred to weakly unless
+  `__weakref__` is among its slots, and on that fallback no container is ever
+  collected. Any `__slots__` class owning a psygnal `Signal` needs the same.
+
 - **Container hooks** - an object a session installs on its application
   container to adjust the application as a whole, rather than any one
   component. A provider implements `ConfiguresBuild` to adjust the build

--- a/src/redsun/containers/__init__.py
+++ b/src/redsun/containers/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from ._config import AppConfig
-from ._hooks import ConfiguresBuild, HookError
+from ._hooks import ConfiguresBuild, ConfiguresSession, HookError
 from .components import declare_device, declare_presenter, declare_view
 from .container import AppContainer, Frontend
 
@@ -11,6 +11,7 @@ __all__ = [
     "AppConfig",
     "AppContainer",
     "ConfiguresBuild",
+    "ConfiguresSession",
     "Frontend",
     "HookError",
     "declare_device",

--- a/src/redsun/containers/_hooks.py
+++ b/src/redsun/containers/_hooks.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 
     from redsun.containers.container import AppContainer
 
-__all__ = ["ConfiguresBuild", "HookError"]
+__all__ = ["ConfiguresBuild", "ConfiguresSession", "HookError"]
 
 logger = logging.getLogger("redsun")
 
@@ -30,6 +30,16 @@ class ConfiguresBuild(Protocol):
     @abstractmethod
     def configure_build(self, container: AppContainer) -> None:
         """Register or remove build phases on *container*."""
+        ...
+
+
+@runtime_checkable
+class ConfiguresSession(Protocol):
+    """Runs once every component is built, wired and injected."""
+
+    @abstractmethod
+    def configure_session(self, container: AppContainer) -> None:
+        """Act on *container* now that the whole session exists."""
         ...
 
 

--- a/src/redsun/containers/container.py
+++ b/src/redsun/containers/container.py
@@ -31,11 +31,13 @@ from typing import (
 
 import yaml
 from ophyd_async.core import Device
+from psygnal import Signal
 
 from redsun.aio import _loop_factory, run_coro
 from redsun.containers._config import AppConfig
 from redsun.containers._hooks import (
     ConfiguresBuild,
+    ConfiguresSession,
     HookError,
     parse_hook_specs,
     resolve_hooks,
@@ -218,6 +220,12 @@ class AppContainer:
     """Application container for MVP architecture."""
 
     __slots__ = (
+        # psygnal holds a signal's owner weakly and drops its per-owner cache
+        # entry through weakref.finalize. Both fall back to a strong reference
+        # when the owner cannot be weakly referenced, which a slotted class
+        # cannot unless __weakref__ is one of its slots - and then no container
+        # is ever collected.
+        "__weakref__",
         "_built_devices",
         "_components",
         "_config",
@@ -234,6 +242,14 @@ class AppContainer:
     _view_components: ClassVar[dict[str, _ViewComponent]] = {}
     _config_path: ClassVar[Path | None] = None
 
+    sig_phase_complete = Signal(str)
+    """Emitted with the name of each build phase as it finishes.
+
+    For watching the build rather than taking part in it: a splash screen
+    naming the step in progress connects to this, where adding a phase per
+    step would register seven phases to display seven labels.
+    """
+
     hooks: ClassVar[Sequence[object]] = ()
     """Hook providers this container installs, ahead of the configured ones.
 
@@ -242,7 +258,11 @@ class AppContainer:
     declare, ahead of its own.
     """
 
-    _hook_protocols: ClassVar[tuple[type, ...]] = (ConfiguresBuild, HasShutdown)
+    _hook_protocols: ClassVar[tuple[type, ...]] = (
+        ConfiguresBuild,
+        ConfiguresSession,
+        HasShutdown,
+    )
     """The hook protocols this container calls.
 
     A provider satisfying none of them is refused, since it would silently do
@@ -524,8 +544,15 @@ class AppContainer:
         for name, phase in self._phases.items():
             phase()
             logger.debug(f"Build phase '{name}' complete")
+            self.sig_phase_complete.emit(name)
 
+        # before the session hooks, so that a hook reading `views`,
+        # `presenters` or `devices` is not turned away by their build guard
         self._is_built = True
+        for hook in self._hooks:
+            if isinstance(hook, ConfiguresSession):
+                hook.configure_session(self)
+
         logger.info(
             f"Container built: "
             f"{len(self._device_components)} devices, "

--- a/tests/container/mock_pkg/hooks.py
+++ b/tests/container/mock_pkg/hooks.py
@@ -47,3 +47,27 @@ class FailingShutdownHook:
 
     def shutdown(self) -> None:
         raise RuntimeError("teardown blew up")
+
+
+class SessionHook:
+    """Records the components it can see once the session is built."""
+
+    def __init__(self) -> None:
+        self.saw: dict[str, int] | None = None
+
+    def configure_session(self, container: AppContainer) -> None:
+        self.saw = {
+            "devices": len(container.devices),
+            "presenters": len(container.presenters),
+            "views": len(container.views),
+        }
+
+
+class PhaseWatcher:
+    """Records every phase name the container reports finishing."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def configure_build(self, container: AppContainer) -> None:
+        container.sig_phase_complete.connect(self.seen.append)

--- a/tests/container/test_hooks.py
+++ b/tests/container/test_hooks.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import gc
 import logging
+import weakref
 
 import pytest
 from mock_pkg import hooks as mock_hooks
+from mock_pkg.device import MyMotor
 
-from redsun.containers import AppContainer, HookError
+from redsun.containers import AppContainer, HookError, declare_device
 
 _PROVIDER = "mock_pkg.hooks:RecordingHook"
 
@@ -279,3 +282,73 @@ class TestHookTeardown:
         app.shutdown()
 
         assert app.phases == AppContainer().phases
+
+
+class TestSessionMoment:
+    """Tests for the after-the-session-is-built moment and its progress signal."""
+
+    def test_a_session_hook_sees_a_finished_container(self) -> None:
+        hook = mock_hooks.SessionHook()
+
+        class TestApp(AppContainer):
+            hooks = (hook,)
+
+            motor = declare_device(
+                MyMotor,
+                axis=["X"],
+                step_size={"X": 0.1},
+                egu="mm",
+                integer=1,
+                floating=1.0,
+                string="s",
+            )
+
+        TestApp().build()
+
+        assert hook.saw == {"devices": 1, "presenters": 0, "views": 0}
+
+    def test_the_phase_signal_reports_every_phase_in_order(self) -> None:
+        watcher = mock_hooks.PhaseWatcher()
+
+        class TestApp(AppContainer):
+            hooks = (watcher,)
+
+        app = TestApp().build()
+
+        assert watcher.seen == app.phases
+
+    def test_the_phase_signal_reports_a_registered_phase_too(self) -> None:
+        seen: list[str] = []
+        app = AppContainer()
+        app.sig_phase_complete.connect(seen.append)
+        app.register_phase("mine", lambda: None, after="devices")
+
+        app.build()
+
+        assert seen == app.phases
+        assert "mine" in seen
+
+    def test_the_signal_is_per_container(self) -> None:
+        first, second = AppContainer(), AppContainer()
+
+        assert first.sig_phase_complete is not second.sig_phase_complete
+
+    def test_a_container_is_collected_once_dropped(self) -> None:
+        # psygnal refers to a signal's owner weakly, and falls back to a strong
+        # reference when it cannot. A slotted class cannot be referred to
+        # weakly unless __weakref__ is one of its slots, and on that fallback
+        # no container is ever collected.
+        gc.collect()
+        cache = AppContainer.__dict__["sig_phase_complete"]._signal_instance_cache
+        before = len(cache)
+
+        app = AppContainer()
+        app.sig_phase_complete.connect(lambda _: None)
+        ref = weakref.ref(app)
+        assert len(cache) == before + 1
+
+        del app
+        gc.collect()
+
+        assert ref() is None
+        assert len(cache) == before


### PR DESCRIPTION
- run the hook when session is built
- add a signal that notifies when one of the building phases is completed; for now it carries only the name of the just-completed phase, in the future the intent is to better map the building phases to add more custom hooks and emit more custom signals